### PR TITLE
extend WithRefOrSpec and add some tests

### DIFF
--- a/spec/callback.go
+++ b/spec/callback.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 )
@@ -45,6 +46,26 @@ func NewCallbackSpec() *RefOrSpec[Extendable[Callback]] {
 // NewCallbackRef creates Ref object.
 func NewCallbackRef(ref *Ref) *RefOrSpec[Extendable[Callback]] {
 	return NewRefOrSpec[Extendable[Callback]](ref, nil)
+}
+
+// WithPathItem adds the PathItem object to the Callback map.
+func (o *Callback) WithPathItem(name string, v any) *Callback {
+	var p *RefOrSpec[Extendable[PathItem]]
+	switch spec := v.(type) {
+	case *RefOrSpec[Extendable[PathItem]]:
+		p = spec
+	case *Extendable[PathItem]:
+		p = NewRefOrSpec[Extendable[PathItem]](nil, spec)
+	case *PathItem:
+		p = NewRefOrSpec[Extendable[PathItem]](nil, NewExtendable(spec))
+	default:
+		panic(fmt.Errorf("wrong Callback type: %T", spec))
+	}
+	if o.Callback == nil {
+		o.Callback = make(map[string]*RefOrSpec[Extendable[PathItem]])
+	}
+	o.Callback[name] = p
+	return o
 }
 
 // MarshalJSON implements json.Marshaler interface.

--- a/spec/callback_test.go
+++ b/spec/callback_test.go
@@ -1,0 +1,56 @@
+package spec_test
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/sv-tools/openapi/spec"
+	"testing"
+)
+
+func TestCallback_WithPathItem(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		create func() any
+	}{
+		{
+			name: "path item spec",
+			create: func() any {
+				o := spec.NewPathItemSpec()
+				o.Spec.Spec.Description = "test"
+				return o.Spec.Spec
+			},
+		},
+		{
+			name: "path item ext spec",
+			create: func() any {
+				o := spec.NewPathItemSpec()
+				o.Spec.Spec.Description = "test"
+				return o.Spec
+			},
+		},
+		{
+			name: "path item ref or spec",
+			create: func() any {
+				o := spec.NewPathItemSpec()
+				o.Spec.Spec.Description = "test"
+				return o
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := spec.NewCallbackSpec().Spec.Spec
+			c.WithPathItem("testPathItem", tt.create())
+			require.Len(t, c.Callback, 1)
+			require.NotNil(t, c.Callback["testPathItem"])
+			require.NotNil(t, c.Callback["testPathItem"].Spec)
+			require.NotNil(t, c.Callback["testPathItem"].Spec.Spec)
+			require.Equal(t, "test", c.Callback["testPathItem"].Spec.Spec.Description)
+		})
+	}
+
+	t.Run("panic", func(t *testing.T) {
+		c := spec.NewCallbackSpec().Spec.Spec
+		require.Panics(t, func() {
+			c.WithPathItem("panic", 42)
+		})
+	})
+}

--- a/spec/components.go
+++ b/spec/components.go
@@ -1,5 +1,7 @@
 package spec
 
+import "fmt"
+
 // Components holds a set of reusable objects for different aspects of the OAS.
 // All objects defined within the components object will have no effect on the API unless they are explicitly referenced
 // from properties outside the components object.
@@ -103,7 +105,7 @@ func NewComponents() *Extendable[Components] {
 	return NewExtendable(&Components{})
 }
 
-// WithRefOrSpec adds the given object to the appropriate list based on type and returns the current object (self|this).
+// WithRefOrSpec adds the given object to the appropriate list based on a type and returns the current object (self|this).
 func (o *Components) WithRefOrSpec(name string, v any) *Components {
 	switch spec := v.(type) {
 	case *RefOrSpec[Schema]:
@@ -111,51 +113,148 @@ func (o *Components) WithRefOrSpec(name string, v any) *Components {
 			o.Schemas = make(map[string]*RefOrSpec[Schema], 1)
 		}
 		o.Schemas[name] = spec
+	case *Schema:
+		if o.Schemas == nil {
+			o.Schemas = make(map[string]*RefOrSpec[Schema], 1)
+		}
+		o.Schemas[name] = NewRefOrSpec(nil, spec)
 	case *RefOrSpec[Extendable[Response]]:
 		if o.Responses == nil {
 			o.Responses = make(map[string]*RefOrSpec[Extendable[Response]], 1)
 		}
 		o.Responses[name] = spec
+	case *Extendable[Response]:
+		if o.Responses == nil {
+			o.Responses = make(map[string]*RefOrSpec[Extendable[Response]], 1)
+		}
+		o.Responses[name] = NewRefOrSpec(nil, spec)
+	case *Response:
+		if o.Responses == nil {
+			o.Responses = make(map[string]*RefOrSpec[Extendable[Response]], 1)
+		}
+		o.Responses[name] = NewRefOrSpec(nil, NewExtendable(spec))
 	case *RefOrSpec[Extendable[Parameter]]:
 		if o.Parameters == nil {
 			o.Parameters = make(map[string]*RefOrSpec[Extendable[Parameter]], 1)
 		}
 		o.Parameters[name] = spec
+	case *Extendable[Parameter]:
+		if o.Parameters == nil {
+			o.Parameters = make(map[string]*RefOrSpec[Extendable[Parameter]], 1)
+		}
+		o.Parameters[name] = NewRefOrSpec(nil, spec)
+	case *Parameter:
+		if o.Parameters == nil {
+			o.Parameters = make(map[string]*RefOrSpec[Extendable[Parameter]], 1)
+		}
+		o.Parameters[name] = NewRefOrSpec(nil, NewExtendable(spec))
 	case *RefOrSpec[Extendable[Example]]:
 		if o.Examples == nil {
 			o.Examples = make(map[string]*RefOrSpec[Extendable[Example]], 1)
 		}
 		o.Examples[name] = spec
+	case *Extendable[Example]:
+		if o.Examples == nil {
+			o.Examples = make(map[string]*RefOrSpec[Extendable[Example]], 1)
+		}
+		o.Examples[name] = NewRefOrSpec(nil, spec)
+	case *Example:
+		if o.Examples == nil {
+			o.Examples = make(map[string]*RefOrSpec[Extendable[Example]], 1)
+		}
+		o.Examples[name] = NewRefOrSpec(nil, NewExtendable(spec))
 	case *RefOrSpec[Extendable[RequestBody]]:
 		if o.RequestBodies == nil {
 			o.RequestBodies = make(map[string]*RefOrSpec[Extendable[RequestBody]], 1)
 		}
 		o.RequestBodies[name] = spec
+	case *Extendable[RequestBody]:
+		if o.RequestBodies == nil {
+			o.RequestBodies = make(map[string]*RefOrSpec[Extendable[RequestBody]], 1)
+		}
+		o.RequestBodies[name] = NewRefOrSpec(nil, spec)
+	case *RequestBody:
+		if o.RequestBodies == nil {
+			o.RequestBodies = make(map[string]*RefOrSpec[Extendable[RequestBody]], 1)
+		}
+		o.RequestBodies[name] = NewRefOrSpec(nil, NewExtendable(spec))
 	case *RefOrSpec[Extendable[Header]]:
 		if o.Headers == nil {
 			o.Headers = make(map[string]*RefOrSpec[Extendable[Header]], 1)
 		}
 		o.Headers[name] = spec
+	case *Extendable[Header]:
+		if o.Headers == nil {
+			o.Headers = make(map[string]*RefOrSpec[Extendable[Header]], 1)
+		}
+		o.Headers[name] = NewRefOrSpec(nil, spec)
+	case *Header:
+		if o.Headers == nil {
+			o.Headers = make(map[string]*RefOrSpec[Extendable[Header]], 1)
+		}
+		o.Headers[name] = NewRefOrSpec(nil, NewExtendable(spec))
 	case *RefOrSpec[Extendable[SecurityScheme]]:
 		if o.SecuritySchemes == nil {
 			o.SecuritySchemes = make(map[string]*RefOrSpec[Extendable[SecurityScheme]], 1)
 		}
 		o.SecuritySchemes[name] = spec
+	case *Extendable[SecurityScheme]:
+		if o.SecuritySchemes == nil {
+			o.SecuritySchemes = make(map[string]*RefOrSpec[Extendable[SecurityScheme]], 1)
+		}
+		o.SecuritySchemes[name] = NewRefOrSpec(nil, spec)
+	case *SecurityScheme:
+		if o.SecuritySchemes == nil {
+			o.SecuritySchemes = make(map[string]*RefOrSpec[Extendable[SecurityScheme]], 1)
+		}
+		o.SecuritySchemes[name] = NewRefOrSpec(nil, NewExtendable(spec))
 	case *RefOrSpec[Extendable[Link]]:
 		if o.Links == nil {
 			o.Links = make(map[string]*RefOrSpec[Extendable[Link]], 1)
 		}
 		o.Links[name] = spec
+	case *Extendable[Link]:
+		if o.Links == nil {
+			o.Links = make(map[string]*RefOrSpec[Extendable[Link]], 1)
+		}
+		o.Links[name] = NewRefOrSpec(nil, spec)
+	case *Link:
+		if o.Links == nil {
+			o.Links = make(map[string]*RefOrSpec[Extendable[Link]], 1)
+		}
+		o.Links[name] = NewRefOrSpec(nil, NewExtendable(spec))
 	case *RefOrSpec[Extendable[Callback]]:
 		if o.Callbacks == nil {
 			o.Callbacks = make(map[string]*RefOrSpec[Extendable[Callback]], 1)
 		}
 		o.Callbacks[name] = spec
+	case *Extendable[Callback]:
+		if o.Callbacks == nil {
+			o.Callbacks = make(map[string]*RefOrSpec[Extendable[Callback]], 1)
+		}
+		o.Callbacks[name] = NewRefOrSpec(nil, spec)
+	case *Callback:
+		if o.Callbacks == nil {
+			o.Callbacks = make(map[string]*RefOrSpec[Extendable[Callback]], 1)
+		}
+		o.Callbacks[name] = NewRefOrSpec(nil, NewExtendable(spec))
 	case *RefOrSpec[Extendable[PathItem]]:
 		if o.Paths == nil {
 			o.Paths = make(map[string]*RefOrSpec[Extendable[PathItem]], 1)
 		}
 		o.Paths[name] = spec
+	case *Extendable[PathItem]:
+		if o.Paths == nil {
+			o.Paths = make(map[string]*RefOrSpec[Extendable[PathItem]], 1)
+		}
+		o.Paths[name] = NewRefOrSpec(nil, spec)
+	case *PathItem:
+		if o.Paths == nil {
+			o.Paths = make(map[string]*RefOrSpec[Extendable[PathItem]], 1)
+		}
+		o.Paths[name] = NewRefOrSpec(nil, NewExtendable(spec))
+	default:
+		panic(fmt.Errorf("wrong component type: %T", spec))
 	}
 	return o
 }

--- a/spec/components_test.go
+++ b/spec/components_test.go
@@ -1,0 +1,506 @@
+package spec_test
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/sv-tools/openapi/spec"
+	"testing"
+)
+
+func TestComponents_WithRefOrSpec(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		create func() (string, any)
+		check  func(tb testing.TB, c *spec.Components)
+	}{
+		{
+			name: "schema spec",
+			create: func() (string, any) {
+				o := spec.NewSchemaSpec()
+				o.Spec.Title = "test"
+				return "testSchema", o.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Schemas, 1)
+				require.NotNil(tb, c.Schemas["testSchema"])
+				require.NotNil(tb, c.Schemas["testSchema"].Spec)
+				require.Equal(tb, "test", c.Schemas["testSchema"].Spec.Title)
+			},
+		},
+		{
+			name: "schema ref or spec",
+			create: func() (string, any) {
+				o := spec.NewSchemaSpec()
+				o.Spec.Title = "test"
+				return "testSchema", o
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Schemas, 1)
+				require.NotNil(tb, c.Schemas["testSchema"])
+				require.NotNil(tb, c.Schemas["testSchema"].Spec)
+				require.Equal(tb, "test", c.Schemas["testSchema"].Spec.Title)
+			},
+		},
+		{
+			name: "response spec",
+			create: func() (string, any) {
+				o := spec.NewResponseSpec()
+				o.Spec.Spec.Description = "test"
+				return "testResponse", o.Spec.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Responses, 1)
+				require.NotNil(tb, c.Responses["testResponse"])
+				require.NotNil(tb, c.Responses["testResponse"].Spec)
+				require.NotNil(tb, c.Responses["testResponse"].Spec.Spec)
+				require.Equal(tb, "test", c.Responses["testResponse"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "response ext spec",
+			create: func() (string, any) {
+				o := spec.NewResponseSpec()
+				o.Spec.Spec.Description = "test"
+				return "testResponse", o.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Responses, 1)
+				require.NotNil(tb, c.Responses["testResponse"])
+				require.NotNil(tb, c.Responses["testResponse"].Spec)
+				require.NotNil(tb, c.Responses["testResponse"].Spec.Spec)
+				require.Equal(tb, "test", c.Responses["testResponse"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "response ref or spec",
+			create: func() (string, any) {
+				o := spec.NewResponseSpec()
+				o.Spec.Spec.Description = "test"
+				return "testResponse", o
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Responses, 1)
+				require.NotNil(tb, c.Responses["testResponse"])
+				require.NotNil(tb, c.Responses["testResponse"].Spec)
+				require.NotNil(tb, c.Responses["testResponse"].Spec.Spec)
+				require.Equal(tb, "test", c.Responses["testResponse"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "parameter spec",
+			create: func() (string, any) {
+				o := spec.NewParameterSpec()
+				o.Spec.Spec.Description = "test"
+				return "testParameter", o.Spec.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Parameters, 1)
+				require.NotNil(tb, c.Parameters["testParameter"])
+				require.NotNil(tb, c.Parameters["testParameter"].Spec)
+				require.NotNil(tb, c.Parameters["testParameter"].Spec.Spec)
+				require.Equal(tb, "test", c.Parameters["testParameter"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "parameter ext spec",
+			create: func() (string, any) {
+				o := spec.NewParameterSpec()
+				o.Spec.Spec.Description = "test"
+				return "testParameter", o.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Parameters, 1)
+				require.NotNil(tb, c.Parameters["testParameter"])
+				require.NotNil(tb, c.Parameters["testParameter"].Spec)
+				require.NotNil(tb, c.Parameters["testParameter"].Spec.Spec)
+				require.Equal(tb, "test", c.Parameters["testParameter"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "parameter ref or spec",
+			create: func() (string, any) {
+				o := spec.NewParameterSpec()
+				o.Spec.Spec.Description = "test"
+				return "testParameter", o
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Parameters, 1)
+				require.NotNil(tb, c.Parameters["testParameter"])
+				require.NotNil(tb, c.Parameters["testParameter"].Spec)
+				require.NotNil(tb, c.Parameters["testParameter"].Spec.Spec)
+				require.Equal(tb, "test", c.Parameters["testParameter"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "examples spec",
+			create: func() (string, any) {
+				o := spec.NewExampleSpec()
+				o.Spec.Spec.Description = "test"
+				return "testExamples", o.Spec.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Examples, 1)
+				require.NotNil(tb, c.Examples["testExamples"])
+				require.NotNil(tb, c.Examples["testExamples"].Spec)
+				require.NotNil(tb, c.Examples["testExamples"].Spec.Spec)
+				require.Equal(tb, "test", c.Examples["testExamples"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "examples ext spec",
+			create: func() (string, any) {
+				o := spec.NewExampleSpec()
+				o.Spec.Spec.Description = "test"
+				return "testExamples", o.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Examples, 1)
+				require.NotNil(tb, c.Examples["testExamples"])
+				require.NotNil(tb, c.Examples["testExamples"].Spec)
+				require.NotNil(tb, c.Examples["testExamples"].Spec.Spec)
+				require.Equal(tb, "test", c.Examples["testExamples"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "examples ref or spec",
+			create: func() (string, any) {
+				o := spec.NewExampleSpec()
+				o.Spec.Spec.Description = "test"
+				return "testExamples", o
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Examples, 1)
+				require.NotNil(tb, c.Examples["testExamples"])
+				require.NotNil(tb, c.Examples["testExamples"].Spec)
+				require.NotNil(tb, c.Examples["testExamples"].Spec.Spec)
+				require.Equal(tb, "test", c.Examples["testExamples"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "request bodies spec",
+			create: func() (string, any) {
+				o := spec.NewRequestBodySpec()
+				o.Spec.Spec.Description = "test"
+				return "testRequestBodies", o.Spec.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.RequestBodies, 1)
+				require.NotNil(tb, c.RequestBodies["testRequestBodies"])
+				require.NotNil(tb, c.RequestBodies["testRequestBodies"].Spec)
+				require.NotNil(tb, c.RequestBodies["testRequestBodies"].Spec.Spec)
+				require.Equal(tb, "test", c.RequestBodies["testRequestBodies"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "request bodies ext spec",
+			create: func() (string, any) {
+				o := spec.NewRequestBodySpec()
+				o.Spec.Spec.Description = "test"
+				return "testRequestBodies", o.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.RequestBodies, 1)
+				require.NotNil(tb, c.RequestBodies["testRequestBodies"])
+				require.NotNil(tb, c.RequestBodies["testRequestBodies"].Spec)
+				require.NotNil(tb, c.RequestBodies["testRequestBodies"].Spec.Spec)
+				require.Equal(tb, "test", c.RequestBodies["testRequestBodies"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "request bodies ref or spec",
+			create: func() (string, any) {
+				o := spec.NewRequestBodySpec()
+				o.Spec.Spec.Description = "test"
+				return "testRequestBodies", o
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.RequestBodies, 1)
+				require.NotNil(tb, c.RequestBodies["testRequestBodies"])
+				require.NotNil(tb, c.RequestBodies["testRequestBodies"].Spec)
+				require.NotNil(tb, c.RequestBodies["testRequestBodies"].Spec.Spec)
+				require.Equal(tb, "test", c.RequestBodies["testRequestBodies"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "headers spec",
+			create: func() (string, any) {
+				o := spec.NewHeaderSpec()
+				o.Spec.Spec.Description = "test"
+				return "testHeader", o.Spec.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Headers, 1)
+				require.NotNil(tb, c.Headers["testHeader"])
+				require.NotNil(tb, c.Headers["testHeader"].Spec)
+				require.NotNil(tb, c.Headers["testHeader"].Spec.Spec)
+				require.Equal(tb, "test", c.Headers["testHeader"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "headers ext spec",
+			create: func() (string, any) {
+				o := spec.NewHeaderSpec()
+				o.Spec.Spec.Description = "test"
+				return "testHeader", o.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Headers, 1)
+				require.NotNil(tb, c.Headers["testHeader"])
+				require.NotNil(tb, c.Headers["testHeader"].Spec)
+				require.NotNil(tb, c.Headers["testHeader"].Spec.Spec)
+				require.Equal(tb, "test", c.Headers["testHeader"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "headers ref or spec",
+			create: func() (string, any) {
+				o := spec.NewHeaderSpec()
+				o.Spec.Spec.Description = "test"
+				return "testHeader", o
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Headers, 1)
+				require.NotNil(tb, c.Headers["testHeader"])
+				require.NotNil(tb, c.Headers["testHeader"].Spec)
+				require.NotNil(tb, c.Headers["testHeader"].Spec.Spec)
+				require.Equal(tb, "test", c.Headers["testHeader"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "security schemes spec",
+			create: func() (string, any) {
+				o := spec.NewSecuritySchemeSpec()
+				o.Spec.Spec.Description = "test"
+				return "testSecurityScheme", o.Spec.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.SecuritySchemes, 1)
+				require.NotNil(tb, c.SecuritySchemes["testSecurityScheme"])
+				require.NotNil(tb, c.SecuritySchemes["testSecurityScheme"].Spec)
+				require.NotNil(tb, c.SecuritySchemes["testSecurityScheme"].Spec.Spec)
+				require.Equal(tb, "test", c.SecuritySchemes["testSecurityScheme"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "security schemes ext spec",
+			create: func() (string, any) {
+				o := spec.NewSecuritySchemeSpec()
+				o.Spec.Spec.Description = "test"
+				return "testSecurityScheme", o.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.SecuritySchemes, 1)
+				require.NotNil(tb, c.SecuritySchemes["testSecurityScheme"])
+				require.NotNil(tb, c.SecuritySchemes["testSecurityScheme"].Spec)
+				require.NotNil(tb, c.SecuritySchemes["testSecurityScheme"].Spec.Spec)
+				require.Equal(tb, "test", c.SecuritySchemes["testSecurityScheme"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "security schemes ref or spec",
+			create: func() (string, any) {
+				o := spec.NewSecuritySchemeSpec()
+				o.Spec.Spec.Description = "test"
+				return "testSecurityScheme", o
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.SecuritySchemes, 1)
+				require.NotNil(tb, c.SecuritySchemes["testSecurityScheme"])
+				require.NotNil(tb, c.SecuritySchemes["testSecurityScheme"].Spec)
+				require.NotNil(tb, c.SecuritySchemes["testSecurityScheme"].Spec.Spec)
+				require.Equal(tb, "test", c.SecuritySchemes["testSecurityScheme"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "link spec",
+			create: func() (string, any) {
+				o := spec.NewLinkSpec()
+				o.Spec.Spec.Description = "test"
+				return "testLink", o.Spec.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Links, 1)
+				require.NotNil(tb, c.Links["testLink"])
+				require.NotNil(tb, c.Links["testLink"].Spec)
+				require.NotNil(tb, c.Links["testLink"].Spec.Spec)
+				require.Equal(tb, "test", c.Links["testLink"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "link ext spec",
+			create: func() (string, any) {
+				o := spec.NewLinkSpec()
+				o.Spec.Spec.Description = "test"
+				return "testLink", o.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Links, 1)
+				require.NotNil(tb, c.Links["testLink"])
+				require.NotNil(tb, c.Links["testLink"].Spec)
+				require.NotNil(tb, c.Links["testLink"].Spec.Spec)
+				require.Equal(tb, "test", c.Links["testLink"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "link ref or spec",
+			create: func() (string, any) {
+				o := spec.NewLinkSpec()
+				o.Spec.Spec.Description = "test"
+				return "testLink", o
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Links, 1)
+				require.NotNil(tb, c.Links["testLink"])
+				require.NotNil(tb, c.Links["testLink"].Spec)
+				require.NotNil(tb, c.Links["testLink"].Spec.Spec)
+				require.Equal(tb, "test", c.Links["testLink"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "callback spec",
+			create: func() (string, any) {
+				p := spec.NewPathItemSpec()
+				p.Spec.Spec.Description = "test"
+				o := spec.NewCallbackSpec()
+				o.Spec.Spec.WithPathItem("testPath", p)
+				return "testCallback", o.Spec.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Callbacks, 1)
+				require.NotNil(tb, c.Callbacks["testCallback"])
+				require.NotNil(tb, c.Callbacks["testCallback"].Spec)
+				require.NotNil(tb, c.Callbacks["testCallback"].Spec.Spec)
+				paths := c.Callbacks["testCallback"].Spec.Spec.Callback
+				require.Len(tb, paths, 1)
+				require.NotNil(tb, paths["testPath"])
+				require.NotNil(tb, paths["testPath"].Spec)
+				require.NotNil(tb, paths["testPath"].Spec.Spec)
+				require.Equal(tb, "test", paths["testPath"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "callback spec",
+			create: func() (string, any) {
+				p := spec.NewPathItemSpec()
+				p.Spec.Spec.Description = "test"
+				o := spec.NewCallbackSpec()
+				o.Spec.Spec.WithPathItem("testPath", p)
+				return "testCallback", o.Spec.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Callbacks, 1)
+				require.NotNil(tb, c.Callbacks["testCallback"])
+				require.NotNil(tb, c.Callbacks["testCallback"].Spec)
+				require.NotNil(tb, c.Callbacks["testCallback"].Spec.Spec)
+				paths := c.Callbacks["testCallback"].Spec.Spec.Callback
+				require.Len(tb, paths, 1)
+				require.NotNil(tb, paths["testPath"])
+				require.NotNil(tb, paths["testPath"].Spec)
+				require.NotNil(tb, paths["testPath"].Spec.Spec)
+				require.Equal(tb, "test", paths["testPath"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "callback ext spec",
+			create: func() (string, any) {
+				p := spec.NewPathItemSpec()
+				p.Spec.Spec.Description = "test"
+				o := spec.NewCallbackSpec()
+				o.Spec.Spec.WithPathItem("testPath", p)
+				return "testCallback", o.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Callbacks, 1)
+				require.NotNil(tb, c.Callbacks["testCallback"])
+				require.NotNil(tb, c.Callbacks["testCallback"].Spec)
+				require.NotNil(tb, c.Callbacks["testCallback"].Spec.Spec)
+				paths := c.Callbacks["testCallback"].Spec.Spec.Callback
+				require.Len(tb, paths, 1)
+				require.NotNil(tb, paths["testPath"])
+				require.NotNil(tb, paths["testPath"].Spec)
+				require.NotNil(tb, paths["testPath"].Spec.Spec)
+				require.Equal(tb, "test", paths["testPath"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "callback ref or spec",
+			create: func() (string, any) {
+				p := spec.NewPathItemSpec()
+				p.Spec.Spec.Description = "test"
+				o := spec.NewCallbackSpec()
+				o.Spec.Spec.WithPathItem("testPath", p)
+				return "testCallback", o
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Callbacks, 1)
+				require.NotNil(tb, c.Callbacks["testCallback"])
+				require.NotNil(tb, c.Callbacks["testCallback"].Spec)
+				require.NotNil(tb, c.Callbacks["testCallback"].Spec.Spec)
+				paths := c.Callbacks["testCallback"].Spec.Spec.Callback
+				require.Len(tb, paths, 1)
+				require.NotNil(tb, paths["testPath"])
+				require.NotNil(tb, paths["testPath"].Spec)
+				require.NotNil(tb, paths["testPath"].Spec.Spec)
+				require.Equal(tb, "test", paths["testPath"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "path item spec",
+			create: func() (string, any) {
+				o := spec.NewPathItemSpec()
+				o.Spec.Spec.Description = "test"
+				return "testPathItem", o.Spec.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Paths, 1)
+				require.NotNil(tb, c.Paths["testPathItem"])
+				require.NotNil(tb, c.Paths["testPathItem"].Spec)
+				require.NotNil(tb, c.Paths["testPathItem"].Spec.Spec)
+				require.Equal(tb, "test", c.Paths["testPathItem"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "path item ext spec",
+			create: func() (string, any) {
+				o := spec.NewPathItemSpec()
+				o.Spec.Spec.Description = "test"
+				return "testPathItem", o.Spec
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Paths, 1)
+				require.NotNil(tb, c.Paths["testPathItem"])
+				require.NotNil(tb, c.Paths["testPathItem"].Spec)
+				require.NotNil(tb, c.Paths["testPathItem"].Spec.Spec)
+				require.Equal(tb, "test", c.Paths["testPathItem"].Spec.Spec.Description)
+			},
+		},
+		{
+			name: "path item ref or spec",
+			create: func() (string, any) {
+				o := spec.NewPathItemSpec()
+				o.Spec.Spec.Description = "test"
+				return "testPathItem", o
+			},
+			check: func(tb testing.TB, c *spec.Components) {
+				require.Len(tb, c.Paths, 1)
+				require.NotNil(tb, c.Paths["testPathItem"])
+				require.NotNil(tb, c.Paths["testPathItem"].Spec)
+				require.NotNil(tb, c.Paths["testPathItem"].Spec.Spec)
+				require.Equal(tb, "test", c.Paths["testPathItem"].Spec.Spec.Description)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := spec.NewComponents().Spec
+			name, obj := tt.create()
+			c.WithRefOrSpec(name, obj)
+			tt.check(t, c)
+		})
+	}
+
+	t.Run("panic", func(t *testing.T) {
+		c := spec.NewComponents().Spec
+		require.Panics(t, func() {
+			c.WithRefOrSpec("panic", 42)
+		})
+	})
+}

--- a/spec/paths.go
+++ b/spec/paths.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 )
@@ -42,6 +43,26 @@ type Paths struct {
 func NewPaths() *Extendable[Paths] {
 	p := map[string]*RefOrSpec[Extendable[PathItem]]{}
 	return NewExtendable(&Paths{Paths: p})
+}
+
+// WithPathItem adds the PathItem object to the Paths map.
+func (o *Paths) WithPathItem(name string, v any) *Paths {
+	var p *RefOrSpec[Extendable[PathItem]]
+	switch spec := v.(type) {
+	case *RefOrSpec[Extendable[PathItem]]:
+		p = spec
+	case *Extendable[PathItem]:
+		p = NewRefOrSpec[Extendable[PathItem]](nil, spec)
+	case *PathItem:
+		p = NewRefOrSpec[Extendable[PathItem]](nil, NewExtendable(spec))
+	default:
+		panic(fmt.Errorf("wrong PathItem type: %T", spec))
+	}
+	if o.Paths == nil {
+		o.Paths = make(map[string]*RefOrSpec[Extendable[PathItem]])
+	}
+	o.Paths[name] = p
+	return o
 }
 
 // MarshalJSON implements json.Marshaler interface.

--- a/spec/paths_test.go
+++ b/spec/paths_test.go
@@ -1,0 +1,56 @@
+package spec_test
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/sv-tools/openapi/spec"
+	"testing"
+)
+
+func TestPaths_WithPathItem(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		create func() any
+	}{
+		{
+			name: "path item spec",
+			create: func() any {
+				o := spec.NewPathItemSpec()
+				o.Spec.Spec.Description = "test"
+				return o.Spec.Spec
+			},
+		},
+		{
+			name: "path item ext spec",
+			create: func() any {
+				o := spec.NewPathItemSpec()
+				o.Spec.Spec.Description = "test"
+				return o.Spec
+			},
+		},
+		{
+			name: "path item ref or spec",
+			create: func() any {
+				o := spec.NewPathItemSpec()
+				o.Spec.Spec.Description = "test"
+				return o
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := spec.NewPaths().Spec
+			c.WithPathItem("testPathItem", tt.create())
+			require.Len(t, c.Paths, 1)
+			require.NotNil(t, c.Paths["testPathItem"])
+			require.NotNil(t, c.Paths["testPathItem"].Spec)
+			require.NotNil(t, c.Paths["testPathItem"].Spec.Spec)
+			require.Equal(t, "test", c.Paths["testPathItem"].Spec.Spec.Description)
+		})
+	}
+
+	t.Run("panic", func(t *testing.T) {
+		c := spec.NewPaths().Spec
+		require.Panics(t, func() {
+			c.WithPathItem("panic", 42)
+		})
+	})
+}


### PR DESCRIPTION
- Support simple types (non Extendable, not RefOrSpec) in components.WithRefOrSpec
- Add WithPathItem function to Paths and Callback objects
- Add the unit tests for new functions