### PR TITLE
feat(parser): add ParseObject to generate OpenAPI schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ go get github.com/sv-tools/openapi
     * `Validator.ValidateData()` method validates the data.
     * `Validator.ValidateDataAsJSON()` method validates the data by converting it into `map[string]any` type first using `json.Marshal` and `json.Unmarshal`. 
       **WARNING**: the function is slow due to double conversion.
+  * Added `ParseObject` function to create `SchemaBuilder` by parsing an object.
+    The function supports `json`, `yaml` and `openapi` field tags for the structs.
   * Use OpenAPI `v3.1.1` by default.
 
 ## Features

--- a/bool_or_schema.go
+++ b/bool_or_schema.go
@@ -78,7 +78,7 @@ func NewBoolOrSchema(v any) *BoolOrSchema {
 		return &BoolOrSchema{Allowed: v}
 	case *RefOrSpec[Schema]:
 		return &BoolOrSchema{Schema: v}
-	case *SchemaBulder:
+	case *SchemaBuilder:
 		return &BoolOrSchema{Schema: v.Build()}
 	default:
 		return nil

--- a/components.go
+++ b/components.go
@@ -181,6 +181,7 @@ func (o *Components) validateSpec(location string, validator *Validator) []*vali
 		}
 		errs = append(errs, v.validateSpec(joinLoc(location, "responses", k), validator)...)
 	}
+
 	for k, v := range o.Parameters {
 		if !namePattern.MatchString(k) {
 			errs = append(errs, newValidationError(joinLoc(location, "parameters", k), "invalid name %q, must match %q", k, namePattern.String()))

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,319 @@
+package openapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type parseOptions struct {
+	DefaultEncoding string // default encoding for the schema, used for []byte
+}
+
+type ParseOption func(*parseOptions)
+
+// WithDefaultEncoding sets the default encoding for the schema for []byte fields.
+// The default encoding is Base64Encoding.
+func WithDefaultEncoding(v string) ParseOption {
+	return func(opts *parseOptions) {
+		opts.DefaultEncoding = v
+	}
+}
+
+const is64Bit = uint64(^uintptr(0)) == ^uint64(0)
+
+// ParseObject parses the object and returns the schema or the reference to the schema.
+//
+// The object can be a struct, pointer to struct, map, slice, pointer to map or slice, or any other type.
+// The object can contain fields with `json`, `yaml` or `openapi` tags.
+//
+//	`openapi:"<name>[,ref:<ref> || any other tags]"` tag:
+//	  - <name> is the name of the field in the schema, can be "-" to skip the field or empty to use the name from json, yaml tags or original field name.
+//	json schema fields:
+//	  - ref:<ref> is a reference to the schema, can not be used with jsonschema fields.
+//	  - required, marks the field as required by adding it to the required list of the parent schema.
+//	  - deprecated, marks the field as deprecated.
+//	  - title:<title>, sets the title of the field or summary for the fereference.
+//	  - summary:<summary>, sets the summary of the reference.
+//	  - description:<description>, sets the description of the field.
+//	  - type:<type> (boolean, integer, number, string, array, object), may be used multiple times.
+//	    The first usage overrides the default type, all other types are added.
+//	  - addtype:<type>, adds additional type, may be used multiple times.
+//	  - format:<format>, sets the format of the type.
+//
+// The `components` parameter is needed to store the schemas of the structs, and to avoid the circular references.
+// In case of the given object is struct, the function will return a reference to the schema stored in the components
+// Otherwise, the function will return the schema itself.
+func ParseObject(obj any, components *Extendable[Components], opts ...ParseOption) (*SchemaBuilder, error) {
+	opt := &parseOptions{
+		DefaultEncoding: Base64Encoding, // default encoding for []byte
+	}
+	for _, o := range opts {
+		o(opt)
+	}
+	t := reflect.TypeOf(obj)
+	if t == nil {
+		return NewSchemaBuilder().Type(NullType).GoType("nil"), nil
+	}
+	return parseObject(joinLoc("", t.String()), t, components, opt)
+}
+
+// MapKeyMustBeStringError is an error that is returned when the map key is not a string.
+type MapKeyMustBeStringError struct {
+	Location string
+	KeyType  reflect.Kind
+}
+
+func (e *MapKeyMustBeStringError) Error() string {
+	return fmt.Sprintf("%s: unsupported map key type %s, expected string", e.Location, e.KeyType)
+}
+
+func (e *MapKeyMustBeStringError) Is(target error) bool {
+	if target == nil {
+		return false
+	}
+	_, ok := target.(*MapKeyMustBeStringError)
+	return ok
+}
+
+// NewMapKeyMustBeStringError creates a new MapKeyMustBeStringError with the given location and key type.
+func NewMapKeyMustBeStringError(location string, keyType reflect.Kind) *MapKeyMustBeStringError {
+	return &MapKeyMustBeStringError{
+		Location: location,
+		KeyType:  keyType,
+	}
+}
+
+func parseObject(location string, t reflect.Type, components *Extendable[Components], opt *parseOptions) (*SchemaBuilder, error) {
+	if t == nil {
+		return NewSchemaBuilder().Type(NullType).GoType("nil"), nil
+	}
+	kind := t.Kind()
+	if kind == reflect.Ptr {
+		builder, err := parseObject(location, t.Elem(), components, opt)
+		if err != nil {
+			return nil, err
+		}
+		if builder.IsRef() {
+			builder = NewSchemaBuilder().OneOf(
+				builder.Build(),
+				NewSchemaBuilder().Type(NullType).Build(),
+			)
+		} else {
+			builder.AddType(NullType)
+		}
+		return builder, nil
+	}
+	if kind == reflect.Interface {
+		return NewSchemaBuilder().GoType("any"), nil
+	}
+	obj := reflect.New(t).Elem()
+	builder := NewSchemaBuilder().GoType(fmt.Sprintf("%T", obj.Interface()))
+	switch obj.Interface().(type) {
+	case bool:
+		builder.Type(BooleanType)
+	case int, uint:
+		if is64Bit {
+			builder.Type(IntegerType).Format(Int64Format)
+		} else {
+			builder.Type(IntegerType).Format(Int32Format)
+		}
+	case int8, int16, int32, uint8, uint16, uint32:
+		builder.Type(IntegerType).Format(Int32Format)
+	case int64, uint64:
+		builder.Type(IntegerType).Format(Int64Format)
+	case float32:
+		builder.Type(NumberType).Format(FloatFormat)
+	case float64:
+		builder.Type(NumberType).Format(DoubleFormat)
+	case string:
+		builder.Type(StringType)
+	case []byte:
+		builder.Type(StringType).ContentEncoding(opt.DefaultEncoding).GoType("[]byte")
+	case json.Number:
+		builder.Type(NumberType).GoPackage(t.PkgPath())
+	case json.RawMessage:
+		builder.Type(StringType).ContentMediaType("application/json").GoPackage(t.PkgPath())
+	default:
+		switch kind {
+		case reflect.Array, reflect.Slice:
+			var elemSchema any
+			elem := t.Elem()
+			if elem.Kind() == reflect.Interface {
+				elemSchema = true
+			} else {
+				var err error
+				elemSchema, err = parseObject(location, elem, components, opt)
+				if err != nil {
+					return nil, err
+				}
+			}
+			builder.Type(ArrayType).Items(NewBoolOrSchema(elemSchema)).GoType("")
+		case reflect.Map:
+			if k := t.Key().Kind(); k != reflect.String {
+				return nil, NewMapKeyMustBeStringError(location, k)
+			}
+			var elemSchema any
+			elem := t.Elem()
+			if elem.Kind() == reflect.Interface {
+				elemSchema = true
+			} else {
+				var err error
+				elemSchema, err = parseObject(location, elem, components, opt)
+				if err != nil {
+					return nil, err
+				}
+			}
+			builder.Type(ObjectType).AdditionalProperties(NewBoolOrSchema(elemSchema)).GoType("")
+		case reflect.Struct:
+			objName := strings.ReplaceAll(t.PkgPath()+"."+t.Name(), "/", ".")
+			if components.Spec.Schemas[objName] != nil {
+				return NewSchemaBuilder().Ref("#/components/schemas/" + objName), nil
+			}
+			// add a temporary schema to avoid circular references
+			if components.Spec.Schemas == nil {
+				components.Spec.Schemas = make(map[string]*RefOrSpec[Schema], 1)
+			}
+			// reserve the name of the schema
+			const toBeDeleted = "to be deleted"
+			components.Spec.Schemas[objName] = NewSchemaBuilder().Ref(toBeDeleted).Build()
+			var allOf []*RefOrSpec[Schema]
+			for i := range t.NumField() {
+				field := t.Field(i)
+				// skip unexported fields
+				if !field.IsExported() {
+					continue
+				}
+				fieldSchema, err := parseObject(joinLoc(location, field.Name), obj.Field(i).Type(), components, opt)
+				if err != nil {
+					// remove the temporary schema
+					delete(components.Spec.Schemas, objName)
+					return nil, err
+				}
+				if field.Anonymous {
+					allOf = append(allOf, fieldSchema.Build())
+					continue
+				}
+				name := applyTag(&field, fieldSchema, builder)
+				// skip the field if it's marked as "-"
+				if name == "-" {
+					continue
+				}
+				builder.AddProperty(name, fieldSchema.Build())
+			}
+			if len(allOf) > 0 {
+				allOf = append(allOf, builder.Type(ObjectType).GoType("").Build())
+				builder = NewSchemaBuilder().AllOf(allOf...).GoType(t.String())
+			} else {
+				builder.Type(ObjectType)
+			}
+			builder.GoPackage(t.PkgPath())
+			components.Spec.Schemas[objName] = builder.Build()
+			builder = NewSchemaBuilder().Ref("#/components/schemas/" + objName)
+		default:
+			// ignore unsupported types gracefully
+		}
+	}
+
+	return builder, nil
+}
+
+func applyTag(field *reflect.StructField, schema, parent *SchemaBuilder) (name string) {
+	name = field.Name
+
+	for _, tagName := range []string{"json", "yaml"} {
+		if tag, ok := field.Tag.Lookup(tagName); ok {
+			parts := strings.SplitN(tag, ",", 2)
+			if len(parts) > 0 {
+				part := strings.TrimSpace(parts[0])
+				if part != "" {
+					name = part
+					break
+				}
+			}
+		}
+	}
+
+	tag, ok := field.Tag.Lookup("openapi")
+	if !ok {
+		return
+	}
+	parts := strings.Split(tag, ",")
+	if len(parts) == 0 {
+		return
+	}
+
+	if parts[0] != "" {
+		name = parts[0]
+	}
+	if name == "-" {
+		return parts[0]
+	}
+	parts = parts[1:]
+	if len(parts) == 0 {
+		return
+	}
+
+	if strings.HasPrefix(parts[0], "ref:") {
+		schema.Ref(parts[0][4:])
+	}
+
+	var isTypeOverridden bool
+
+	for _, part := range parts {
+		prefixIndex := strings.Index(part, ":")
+		var prefix string
+		if prefixIndex == -1 {
+			prefix = part
+		} else {
+			prefix = part[:prefixIndex]
+			if prefixIndex == len(part)-1 {
+				part = ""
+			}
+			part = part[prefixIndex+1:]
+		}
+
+		// the tags for the references only
+		if schema.IsRef() {
+			switch prefix {
+			case "required":
+				parent.AddRequired(name)
+			case "description":
+				schema.Description(part)
+			case "title", "summary":
+				schema.Title(part)
+			default:
+				// ignore unknown or unsupported tag prefixes gracefully
+			}
+			continue
+		}
+
+		switch prefix {
+		case "required":
+			parent.AddRequired(name)
+		case "deprecated":
+			schema.Deprecated(true)
+		case "title":
+			schema.Title(part)
+		case "description":
+			schema.Description(part)
+		case "type":
+			// first type overrides the default type, all other types are added
+			if !isTypeOverridden {
+				schema.Type(part)
+				isTypeOverridden = true
+			} else {
+				schema.AddType(part)
+			}
+		case "addtype":
+			schema.AddType(part)
+		case "format":
+			schema.Format(part)
+		default:
+			// handle unknown or unsupported tag prefixes gracefully
+		}
+	}
+
+	return
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,0 +1,491 @@
+package openapi_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sv-tools/openapi"
+)
+
+type Simple struct {
+	Fs        string `json:"fs,omitempty" openapi:",format:password" yaml:"FS,omitempty"` // json name should be used
+	Fi        int    `yaml:"FI,omitempty"`                                                // yaml name shuld be used
+	Fb        *bool
+	Fbs       []byte            `json:"fbs,omitempty"                                  openapi:"fBS" yaml:"FS,omitempty"` // openapi name should be used
+	Fm        map[string]string `openapi:",required,title:Map of strings,addtype:null"`                                   // default field name should be used
+	Excluded1 map[string]string `openapi:"-"`
+	Excluded2 map[string]string `json:"-"`
+	Excluded3 map[string]string `yaml:"-"`
+	Fa        any               `openapi:",deprecated"`
+
+	fp string
+}
+
+type Complex struct {
+	Simple          // anonymous field
+	Next   *Complex `json:"Next"` // circular references
+}
+
+type SimpleByRef struct {
+	S Simple `json:"s" openapi:"s,required,title:Simple By Ref,ref:#/components/schemas/github.com.sv-tools.openapi_test.Simple" yaml:"s"`
+}
+
+func TestParseObject(t *testing.T) {
+	trueVar := true
+	strVar := "foo"
+	var nilBool *bool
+
+	for _, tt := range []struct {
+		name               string
+		obj                any
+		expected           *openapi.RefOrSpec[openapi.Schema]
+		expectedComponents *openapi.Components
+		err                string
+	}{
+		{
+			name: "nil",
+			obj:  nil,
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.NullType).
+				GoType("nil").Build(),
+		},
+		{
+			name: "bool true",
+			obj:  true,
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.BooleanType).
+				GoType("bool").Build(),
+		},
+		{
+			name: "bool false",
+			obj:  false,
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.BooleanType).
+				GoType("bool").Build(),
+		},
+		{
+			name: "ptr to bool true",
+			obj:  &trueVar,
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.BooleanType, openapi.NullType).
+				GoType("bool").Build(),
+		},
+		{
+			name: "ptr to bool false",
+			obj:  &trueVar,
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.BooleanType, openapi.NullType).
+				GoType("bool").Build(),
+		},
+		{
+			name: "ptr to *bool nil",
+			obj:  nilBool,
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.BooleanType, openapi.NullType).
+				GoType("bool").Build(),
+		},
+		{
+			name: "int",
+			obj:  42,
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.IntegerType).
+				Format(openapi.Int64Format).
+				GoType("int").Build(),
+		},
+		{
+			name: "int8",
+			obj:  int8(42),
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.IntegerType).
+				Format(openapi.Int32Format).
+				GoType("int8").Build(),
+		},
+		{
+			name: "int32",
+			obj:  int32(42),
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.IntegerType).
+				Format(openapi.Int32Format).
+				GoType("int32").Build(),
+		},
+		{
+			name: "int64",
+			obj:  int64(42),
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.IntegerType).
+				Format(openapi.Int64Format).
+				GoType("int64").Build(),
+		},
+		{
+			name: "uint",
+			obj:  uint(42),
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.IntegerType).
+				Format(openapi.Int64Format).
+				GoType("uint").Build(),
+		},
+		{
+			name: "uint8",
+			obj:  uint8(42),
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.IntegerType).
+				Format(openapi.Int32Format).
+				GoType("uint8").Build(),
+		},
+		{
+			name: "uint32",
+			obj:  uint32(42),
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.IntegerType).
+				Format(openapi.Int32Format).
+				GoType("uint32").Build(),
+		},
+		{
+			name: "uint64",
+			obj:  uint64(42),
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.IntegerType).
+				Format(openapi.Int64Format).
+				GoType("uint64").Build(),
+		},
+		{
+			name: "float32",
+			obj:  float32(42),
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.NumberType).
+				Format(openapi.FloatFormat).
+				GoType("float32").Build(),
+		},
+		{
+			name: "float64",
+			obj:  float64(42),
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.NumberType).
+				Format(openapi.DoubleFormat).
+				GoType("float64").Build(),
+		},
+		{
+			name: "string",
+			obj:  "foo",
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.StringType).
+				GoType("string").Build(),
+		},
+		{
+			name: "bytes",
+			obj:  []byte("foo"),
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.StringType).
+				ContentEncoding(openapi.Base64Encoding).
+				GoType("[]byte").Build(),
+		},
+		{
+			name: "map string",
+			obj:  map[string]string{"foo": "bar"},
+			expected: openapi.NewSchemaBuilder().Type(openapi.ObjectType).
+				AdditionalProperties(openapi.NewBoolOrSchema(openapi.NewSchemaBuilder().
+					Type(openapi.StringType).
+					GoType("string").Build(),
+				)).Build(),
+		},
+		{
+			name: "map string ref string",
+			obj:  map[string]*string{"foo": &strVar},
+			expected: openapi.NewSchemaBuilder().Type(openapi.ObjectType).
+				AdditionalProperties(openapi.NewBoolOrSchema(openapi.NewSchemaBuilder().
+					Type(openapi.StringType, openapi.NullType).
+					GoType("string").Build(),
+				)).Build(),
+		},
+		{
+			name: "map string int",
+			obj:  map[string]int{"foo": 42},
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.ObjectType).
+				AdditionalProperties(openapi.NewBoolOrSchema(openapi.NewSchemaBuilder().
+					Type(openapi.IntegerType).
+					Format(openapi.Int64Format).
+					GoType("int").Build(),
+				)).Build(),
+		},
+		{
+			name: "map string any",
+			obj:  map[string]any{"foo": 42, "bar": "baz"},
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.ObjectType).
+				AdditionalProperties(openapi.NewBoolOrSchema(true)).
+				Build(),
+		},
+		{
+			name: "slice int",
+			obj:  []int{42},
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.ArrayType).
+				Items(openapi.NewBoolOrSchema(openapi.NewSchemaBuilder().
+					Type(openapi.IntegerType).
+					Format(openapi.Int64Format).
+					GoType("int").Build(),
+				)).Build(),
+		},
+		{
+			name: "slice string",
+			obj:  []string{"foo"},
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.ArrayType).
+				Items(openapi.NewBoolOrSchema(openapi.NewSchemaBuilder().
+					Type(openapi.StringType).
+					GoType("string").Build(),
+				)).Build(),
+		},
+		{
+			name: "slice any",
+			obj:  []any{"foo", 42},
+			expected: openapi.NewSchemaBuilder().Type(openapi.ArrayType).
+				Items(openapi.NewBoolOrSchema(true)).
+				Build(),
+		},
+		{
+			name: "double slice any",
+			obj:  [][]any{{"foo", 42}},
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.ArrayType).
+				Items(openapi.NewBoolOrSchema(openapi.NewSchemaBuilder().
+					Type(openapi.ArrayType).
+					Items(openapi.NewBoolOrSchema(true)).
+					Build(),
+				)).Build(),
+		},
+		{
+			name: "triple slice any",
+			obj:  [][][]any{{{"foo", 42}}},
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.ArrayType).
+				Items(openapi.NewBoolOrSchema(openapi.NewSchemaBuilder().
+					Type(openapi.ArrayType).
+					Items(openapi.NewBoolOrSchema(
+						openapi.NewSchemaBuilder().
+							Type(openapi.ArrayType).
+							Items(openapi.NewBoolOrSchema(true)).
+							Build(),
+					)).Build(),
+				)).Build(),
+		},
+		{
+			name: "map string any",
+			obj:  map[string]map[string]any{"xyz": {"foo": 42, "bar": "baz"}},
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.ObjectType).
+				AdditionalProperties(openapi.NewBoolOrSchema(openapi.NewSchemaBuilder().
+					Type(openapi.ObjectType).
+					AdditionalProperties(openapi.NewBoolOrSchema(true)).
+					Build(),
+				)).Build(),
+		},
+		{
+			name: "slice map string any",
+			obj:  []map[string]any{{"foo": 42, "bar": "baz"}},
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.ArrayType).
+				Items(openapi.NewBoolOrSchema(openapi.NewSchemaBuilder().
+					Type(openapi.ObjectType).
+					AdditionalProperties(openapi.NewBoolOrSchema(true)).
+					Build(),
+				)).Build(),
+		},
+		{
+			name: "json number",
+			obj:  json.Number("42"),
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.NumberType).
+				GoPackage("encoding/json").GoType("json.Number").Build(),
+		},
+		{
+			name: "json raw",
+			obj:  json.RawMessage(`"foo"`),
+			expected: openapi.NewSchemaBuilder().
+				Type(openapi.StringType).
+				ContentMediaType("application/json").
+				GoPackage("encoding/json").GoType("json.RawMessage").Build(),
+		},
+		{
+			name: "simple struct",
+			obj: Simple{
+				Fs:  "foo",
+				Fi:  42,
+				Fb:  &trueVar,
+				Fbs: []byte("bar"),
+				Fm:  map[string]string{"baz": "qux"},
+				Fa:  []any{"435", 42, false},
+				fp:  "baz",
+			},
+			expected: openapi.NewSchemaBuilder().Ref("#/components/schemas/github.com.sv-tools.openapi_test.Simple").Build(),
+			expectedComponents: openapi.NewComponents().Spec.Add(
+				"github.com.sv-tools.openapi_test.Simple",
+				openapi.NewSchemaBuilder().
+					Type(openapi.ObjectType).
+					AddProperty("fs", openapi.NewSchemaBuilder().Type(openapi.StringType).GoType("string").Format("password").Build()).
+					AddProperty("FI", openapi.NewSchemaBuilder().Type(openapi.IntegerType).Format(openapi.Int64Format).GoType("int").Build()).
+					AddProperty("Fb", openapi.NewSchemaBuilder().Type(openapi.BooleanType, openapi.NullType).GoType("bool").Build()).
+					AddProperty("fBS", openapi.NewSchemaBuilder().Type(openapi.StringType).ContentEncoding(openapi.Base64Encoding).GoType("[]byte").Build()).
+					AddProperty("Fm", openapi.NewSchemaBuilder().
+						Type(openapi.ObjectType, openapi.NullType).
+						Title("Map of strings").
+						AdditionalProperties(openapi.NewBoolOrSchema(openapi.NewSchemaBuilder().
+							Type(openapi.StringType).
+							GoType("string").Build(),
+						)).Build(),
+					).
+					AddProperty("Fa", openapi.NewSchemaBuilder().
+						Deprecated(true).
+						GoType("any").Build(),
+					).
+					AddRequired("Fm").
+					GoPackage("github.com/sv-tools/openapi_test").GoType("openapi_test.Simple").Build(),
+			),
+		},
+		{
+			name: "complex struct",
+			obj: Complex{
+				Simple: Simple{
+					Fs:  "foo",
+					Fi:  42,
+					Fb:  &trueVar,
+					Fbs: []byte("bar"),
+					Fm:  map[string]string{"baz": "qux"},
+					Fa:  []any{"435", 42, false},
+					fp:  "baz",
+				},
+				Next: &Complex{},
+			},
+			expected: openapi.NewSchemaBuilder().Ref("#/components/schemas/github.com.sv-tools.openapi_test.Complex").Build(),
+			expectedComponents: openapi.NewComponents().Spec.Add(
+				"github.com.sv-tools.openapi_test.Complex",
+				openapi.NewSchemaBuilder().
+					AllOf(
+						openapi.NewSchemaBuilder().Ref("#/components/schemas/github.com.sv-tools.openapi_test.Simple").Build(),
+						openapi.NewSchemaBuilder().
+							Type(openapi.ObjectType).
+							AddProperty("Next", openapi.NewSchemaBuilder().
+								OneOf(
+									openapi.NewSchemaBuilder().Ref("#/components/schemas/github.com.sv-tools.openapi_test.Complex").Build(),
+									openapi.NewSchemaBuilder().Type(openapi.NullType).Build(),
+								).
+								Build(),
+							).
+							Build(),
+					).
+					GoPackage("github.com/sv-tools/openapi_test").GoType("openapi_test.Complex").Build(),
+			).Add(
+				"github.com.sv-tools.openapi_test.Simple",
+				openapi.NewSchemaBuilder().
+					Type(openapi.ObjectType).
+					AddProperty("fs", openapi.NewSchemaBuilder().Type(openapi.StringType).GoType("string").Format("password").Build()).
+					AddProperty("FI", openapi.NewSchemaBuilder().Type(openapi.IntegerType).Format(openapi.Int64Format).GoType("int").Build()).
+					AddProperty("Fb", openapi.NewSchemaBuilder().Type(openapi.BooleanType, openapi.NullType).GoType("bool").Build()).
+					AddProperty("fBS", openapi.NewSchemaBuilder().Type(openapi.StringType).ContentEncoding(openapi.Base64Encoding).GoType("[]byte").Build()).
+					AddProperty("Fm", openapi.NewSchemaBuilder().
+						Type(openapi.ObjectType, openapi.NullType).
+						Title("Map of strings").
+						AdditionalProperties(openapi.NewBoolOrSchema(openapi.NewSchemaBuilder().
+							Type(openapi.StringType).
+							GoType("string").Build(),
+						)).Build(),
+					).
+					AddProperty("Fa", openapi.NewSchemaBuilder().
+						Deprecated(true).
+						GoType("any").Build(),
+					).
+					AddRequired("Fm").
+					GoPackage("github.com/sv-tools/openapi_test").GoType("openapi_test.Simple").Build(),
+			),
+		},
+		{
+			name: "simple by ref",
+			obj: SimpleByRef{
+				S: Simple{},
+			},
+			expected: openapi.NewSchemaBuilder().Ref("#/components/schemas/github.com.sv-tools.openapi_test.SimpleByRef").Build(),
+			expectedComponents: openapi.NewComponents().Spec.Add(
+				"github.com.sv-tools.openapi_test.SimpleByRef",
+				openapi.NewSchemaBuilder().
+					Type(openapi.ObjectType).
+					AddProperty("s", openapi.NewSchemaBuilder().Ref("#/components/schemas/github.com.sv-tools.openapi_test.Simple").Title("Simple By Ref").Build()).
+					Required("s").
+					GoPackage("github.com/sv-tools/openapi_test").GoType("openapi_test.SimpleByRef").Build(),
+			).Add(
+				"github.com.sv-tools.openapi_test.Simple",
+				openapi.NewSchemaBuilder().
+					Type(openapi.ObjectType).
+					AddProperty("fs", openapi.NewSchemaBuilder().Type(openapi.StringType).GoType("string").Format("password").Build()).
+					AddProperty("FI", openapi.NewSchemaBuilder().Type(openapi.IntegerType).Format(openapi.Int64Format).GoType("int").Build()).
+					AddProperty("Fb", openapi.NewSchemaBuilder().Type(openapi.BooleanType, openapi.NullType).GoType("bool").Build()).
+					AddProperty("fBS", openapi.NewSchemaBuilder().Type(openapi.StringType).ContentEncoding(openapi.Base64Encoding).GoType("[]byte").Build()).
+					AddProperty("Fm", openapi.NewSchemaBuilder().
+						Type(openapi.ObjectType, openapi.NullType).
+						Title("Map of strings").
+						AdditionalProperties(openapi.NewBoolOrSchema(openapi.NewSchemaBuilder().
+							Type(openapi.StringType).
+							GoType("string").Build(),
+						)).Build(),
+					).
+					AddProperty("Fa", openapi.NewSchemaBuilder().
+						Deprecated(true).
+						GoType("any").Build(),
+					).
+					AddRequired("Fm").
+					GoPackage("github.com/sv-tools/openapi_test").GoType("openapi_test.Simple").Build(),
+			),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := openapi.NewOpenAPIBuilder().
+				Info(openapi.NewInfoBuilder().Title("Test").Version("1.0").Build()).
+				Components(openapi.NewComponents()).
+				Build()
+			schema, err := openapi.ParseObject(tt.obj, spec.Spec.Components)
+			if tt.err != "" {
+				require.ErrorContains(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, schema)
+
+			actual, err := schema.Build().MarshalJSON()
+			require.NoError(t, err)
+
+			expected, err := tt.expected.MarshalJSON()
+			require.NoError(t, err)
+
+			require.JSONEq(t, string(expected), string(actual))
+
+			if tt.expectedComponents != nil {
+				actualComponents, err := spec.Spec.Components.MarshalJSON()
+				require.NoError(t, err)
+
+				expectedComponents, err := json.Marshal(tt.expectedComponents)
+				require.NoError(t, err)
+
+				require.JSONEq(t, string(expectedComponents), string(actualComponents))
+			}
+
+			spec.Spec.Components.Spec.Add("test", schema.Build())
+			validator, err := openapi.NewValidator(
+				spec,
+				openapi.AllowUnusedComponents(),
+			)
+			require.NoError(t, err)
+
+			require.NoError(t, validator.ValidateSpec())
+
+			value, err := openapi.ConvertToJSON(tt.obj)
+			require.NoError(t, err)
+
+			pretty, _ := json.MarshalIndent(tt.obj, "", "  ")
+			t.Logf("obj: %s", pretty)
+
+			require.NoError(t, validator.ValidateData("#/components/schemas/test", value))
+		})
+	}
+}

--- a/schema.go
+++ b/schema.go
@@ -721,24 +721,24 @@ func (o *Schema) validateSpec(location string, validator *Validator) []*validati
 	return errs
 }
 
-type SchemaBulder struct {
+type SchemaBuilder struct {
 	spec *RefOrSpec[Schema]
 }
 
-func NewSchemaBuilder() *SchemaBulder {
-	return &SchemaBulder{
+func NewSchemaBuilder() *SchemaBuilder {
+	return &SchemaBuilder{
 		spec: NewRefOrSpec[Schema](&Schema{}),
 	}
 }
 
-func (b *SchemaBulder) Build() *RefOrSpec[Schema] {
+func (b *SchemaBuilder) Build() *RefOrSpec[Schema] {
 	if b.spec.Ref != nil {
 		b.spec.Spec = nil
 	}
 	return b.spec
 }
 
-func (b *SchemaBulder) Extensions(v map[string]any) *SchemaBulder {
+func (b *SchemaBuilder) Extensions(v map[string]any) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -746,7 +746,7 @@ func (b *SchemaBulder) Extensions(v map[string]any) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AddExt(name string, value any) *SchemaBulder {
+func (b *SchemaBuilder) AddExt(name string, value any) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -754,7 +754,7 @@ func (b *SchemaBulder) AddExt(name string, value any) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Ref(v string) *SchemaBulder {
+func (b *SchemaBuilder) Ref(v string) *SchemaBuilder {
 	if b.spec.Ref == nil {
 		b.spec.Ref = &Ref{
 			Summary:     b.spec.Spec.Title,
@@ -766,11 +766,11 @@ func (b *SchemaBulder) Ref(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) IsRef() bool {
+func (b *SchemaBuilder) IsRef() bool {
 	return b.spec.Ref != nil
 }
 
-func (b *SchemaBulder) Schema(v string) *SchemaBulder {
+func (b *SchemaBuilder) Schema(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -778,7 +778,7 @@ func (b *SchemaBulder) Schema(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) ID(v string) *SchemaBulder {
+func (b *SchemaBuilder) ID(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -786,7 +786,7 @@ func (b *SchemaBulder) ID(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Defs(v map[string]*RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) Defs(v map[string]*RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -794,7 +794,7 @@ func (b *SchemaBulder) Defs(v map[string]*RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AddDef(name string, value *RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) AddDef(name string, value *RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -805,7 +805,7 @@ func (b *SchemaBulder) AddDef(name string, value *RefOrSpec[Schema]) *SchemaBuld
 	return b
 }
 
-func (b *SchemaBulder) DynamicRef(v string) *SchemaBulder {
+func (b *SchemaBuilder) DynamicRef(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -813,7 +813,7 @@ func (b *SchemaBulder) DynamicRef(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Vocabulary(v map[string]bool) *SchemaBulder {
+func (b *SchemaBuilder) Vocabulary(v map[string]bool) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -821,7 +821,7 @@ func (b *SchemaBulder) Vocabulary(v map[string]bool) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AddVocabulary(name string, value bool) *SchemaBulder {
+func (b *SchemaBuilder) AddVocabulary(name string, value bool) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -832,7 +832,7 @@ func (b *SchemaBulder) AddVocabulary(name string, value bool) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) DynamicAnchor(v string) *SchemaBulder {
+func (b *SchemaBuilder) DynamicAnchor(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -840,7 +840,7 @@ func (b *SchemaBulder) DynamicAnchor(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Type(v ...string) *SchemaBulder {
+func (b *SchemaBuilder) Type(v ...string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -848,7 +848,7 @@ func (b *SchemaBulder) Type(v ...string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AddType(v ...string) *SchemaBulder {
+func (b *SchemaBuilder) AddType(v ...string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -860,7 +860,7 @@ func (b *SchemaBulder) AddType(v ...string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Default(v any) *SchemaBulder {
+func (b *SchemaBuilder) Default(v any) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -868,7 +868,7 @@ func (b *SchemaBulder) Default(v any) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Title(v string) *SchemaBulder {
+func (b *SchemaBuilder) Title(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		b.spec.Ref.Summary = v
 		return b
@@ -877,7 +877,7 @@ func (b *SchemaBulder) Title(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Description(v string) *SchemaBulder {
+func (b *SchemaBuilder) Description(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		b.spec.Ref.Description = v
 		return b
@@ -886,7 +886,7 @@ func (b *SchemaBulder) Description(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Const(v string) *SchemaBulder {
+func (b *SchemaBuilder) Const(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -894,7 +894,7 @@ func (b *SchemaBulder) Const(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Comment(v string) *SchemaBulder {
+func (b *SchemaBuilder) Comment(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -902,7 +902,7 @@ func (b *SchemaBulder) Comment(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Enum(v ...any) *SchemaBulder {
+func (b *SchemaBuilder) Enum(v ...any) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -910,7 +910,7 @@ func (b *SchemaBulder) Enum(v ...any) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AddEnum(v ...any) *SchemaBulder {
+func (b *SchemaBuilder) AddEnum(v ...any) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -918,7 +918,7 @@ func (b *SchemaBulder) AddEnum(v ...any) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Examples(v ...any) *SchemaBulder {
+func (b *SchemaBuilder) Examples(v ...any) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -926,7 +926,7 @@ func (b *SchemaBulder) Examples(v ...any) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AddExamples(v ...any) *SchemaBulder {
+func (b *SchemaBuilder) AddExamples(v ...any) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -934,7 +934,7 @@ func (b *SchemaBulder) AddExamples(v ...any) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) ReadOnly(v bool) *SchemaBulder {
+func (b *SchemaBuilder) ReadOnly(v bool) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -942,7 +942,7 @@ func (b *SchemaBulder) ReadOnly(v bool) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) WriteOnly(v bool) *SchemaBulder {
+func (b *SchemaBuilder) WriteOnly(v bool) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -950,7 +950,7 @@ func (b *SchemaBulder) WriteOnly(v bool) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Deprecated(v bool) *SchemaBulder {
+func (b *SchemaBuilder) Deprecated(v bool) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -958,7 +958,7 @@ func (b *SchemaBulder) Deprecated(v bool) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) ContentSchema(v *RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) ContentSchema(v *RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -966,7 +966,7 @@ func (b *SchemaBulder) ContentSchema(v *RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) ContentMediaType(v string) *SchemaBulder {
+func (b *SchemaBuilder) ContentMediaType(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -974,7 +974,7 @@ func (b *SchemaBulder) ContentMediaType(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) ContentEncoding(v string) *SchemaBulder {
+func (b *SchemaBuilder) ContentEncoding(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -982,7 +982,7 @@ func (b *SchemaBulder) ContentEncoding(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Not(v *RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) Not(v *RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -990,7 +990,7 @@ func (b *SchemaBulder) Not(v *RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AllOf(v ...*RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) AllOf(v ...*RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -998,7 +998,7 @@ func (b *SchemaBulder) AllOf(v ...*RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AddAllOf(v ...*RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) AddAllOf(v ...*RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1006,7 +1006,7 @@ func (b *SchemaBulder) AddAllOf(v ...*RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AnyOf(v ...*RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) AnyOf(v ...*RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1014,7 +1014,7 @@ func (b *SchemaBulder) AnyOf(v ...*RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AddAnyOf(v ...*RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) AddAnyOf(v ...*RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1022,7 +1022,7 @@ func (b *SchemaBulder) AddAnyOf(v ...*RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) OneOf(v ...*RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) OneOf(v ...*RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1030,7 +1030,7 @@ func (b *SchemaBulder) OneOf(v ...*RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AddOneOf(v ...*RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) AddOneOf(v ...*RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1038,7 +1038,7 @@ func (b *SchemaBulder) AddOneOf(v ...*RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) DependentRequired(v map[string][]string) *SchemaBulder {
+func (b *SchemaBuilder) DependentRequired(v map[string][]string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1046,7 +1046,7 @@ func (b *SchemaBulder) DependentRequired(v map[string][]string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AddDependentRequired(name string, value ...string) *SchemaBulder {
+func (b *SchemaBuilder) AddDependentRequired(name string, value ...string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1057,7 +1057,7 @@ func (b *SchemaBulder) AddDependentRequired(name string, value ...string) *Schem
 	return b
 }
 
-func (b *SchemaBulder) DependentSchemas(v map[string]*RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) DependentSchemas(v map[string]*RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1065,7 +1065,7 @@ func (b *SchemaBulder) DependentSchemas(v map[string]*RefOrSpec[Schema]) *Schema
 	return b
 }
 
-func (b *SchemaBulder) AddDependentSchema(name string, value *RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) AddDependentSchema(name string, value *RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1076,7 +1076,7 @@ func (b *SchemaBulder) AddDependentSchema(name string, value *RefOrSpec[Schema])
 	return b
 }
 
-func (b *SchemaBulder) If(v *RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) If(v *RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1084,7 +1084,7 @@ func (b *SchemaBulder) If(v *RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Then(v *RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) Then(v *RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1092,7 +1092,7 @@ func (b *SchemaBulder) Then(v *RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Else(v *RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) Else(v *RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1100,7 +1100,7 @@ func (b *SchemaBulder) Else(v *RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) MultipleOf(v int) *SchemaBulder {
+func (b *SchemaBuilder) MultipleOf(v int) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1108,7 +1108,7 @@ func (b *SchemaBulder) MultipleOf(v int) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Minimum(v int) *SchemaBulder {
+func (b *SchemaBuilder) Minimum(v int) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1116,7 +1116,7 @@ func (b *SchemaBulder) Minimum(v int) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) ExclusiveMinimum(v int) *SchemaBulder {
+func (b *SchemaBuilder) ExclusiveMinimum(v int) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1124,7 +1124,7 @@ func (b *SchemaBulder) ExclusiveMinimum(v int) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Maximum(v int) *SchemaBulder {
+func (b *SchemaBuilder) Maximum(v int) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1132,7 +1132,7 @@ func (b *SchemaBulder) Maximum(v int) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) ExclusiveMaximum(v int) *SchemaBulder {
+func (b *SchemaBuilder) ExclusiveMaximum(v int) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1140,7 +1140,7 @@ func (b *SchemaBulder) ExclusiveMaximum(v int) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) MinLength(v int) *SchemaBulder {
+func (b *SchemaBuilder) MinLength(v int) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1148,7 +1148,7 @@ func (b *SchemaBulder) MinLength(v int) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) MaxLength(v int) *SchemaBulder {
+func (b *SchemaBuilder) MaxLength(v int) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1156,7 +1156,7 @@ func (b *SchemaBulder) MaxLength(v int) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Pattern(v string) *SchemaBulder {
+func (b *SchemaBuilder) Pattern(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1164,7 +1164,7 @@ func (b *SchemaBulder) Pattern(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Format(v string) *SchemaBulder {
+func (b *SchemaBuilder) Format(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1172,7 +1172,7 @@ func (b *SchemaBulder) Format(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Items(v *BoolOrSchema) *SchemaBulder {
+func (b *SchemaBuilder) Items(v *BoolOrSchema) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1180,7 +1180,7 @@ func (b *SchemaBulder) Items(v *BoolOrSchema) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) MaxItems(v int) *SchemaBulder {
+func (b *SchemaBuilder) MaxItems(v int) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1188,7 +1188,7 @@ func (b *SchemaBulder) MaxItems(v int) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) UnevaluatedItems(v *BoolOrSchema) *SchemaBulder {
+func (b *SchemaBuilder) UnevaluatedItems(v *BoolOrSchema) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1196,7 +1196,7 @@ func (b *SchemaBulder) UnevaluatedItems(v *BoolOrSchema) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Contains(v *RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) Contains(v *RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1204,7 +1204,7 @@ func (b *SchemaBulder) Contains(v *RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) MinContains(v int) *SchemaBulder {
+func (b *SchemaBuilder) MinContains(v int) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1212,7 +1212,7 @@ func (b *SchemaBulder) MinContains(v int) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) MaxContains(v int) *SchemaBulder {
+func (b *SchemaBuilder) MaxContains(v int) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1220,7 +1220,7 @@ func (b *SchemaBulder) MaxContains(v int) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) MinItems(v int) *SchemaBulder {
+func (b *SchemaBuilder) MinItems(v int) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1228,7 +1228,7 @@ func (b *SchemaBulder) MinItems(v int) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) UniqueItems(v bool) *SchemaBulder {
+func (b *SchemaBuilder) UniqueItems(v bool) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1236,7 +1236,7 @@ func (b *SchemaBulder) UniqueItems(v bool) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) PrefixItems(v ...*RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) PrefixItems(v ...*RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1244,7 +1244,7 @@ func (b *SchemaBulder) PrefixItems(v ...*RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AddPrefixItems(v ...*RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) AddPrefixItems(v ...*RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1252,7 +1252,7 @@ func (b *SchemaBulder) AddPrefixItems(v ...*RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Properties(v map[string]*RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) Properties(v map[string]*RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1260,7 +1260,7 @@ func (b *SchemaBulder) Properties(v map[string]*RefOrSpec[Schema]) *SchemaBulder
 	return b
 }
 
-func (b *SchemaBulder) AddProperty(name string, value *RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) AddProperty(name string, value *RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1271,7 +1271,7 @@ func (b *SchemaBulder) AddProperty(name string, value *RefOrSpec[Schema]) *Schem
 	return b
 }
 
-func (b *SchemaBulder) PatternProperties(v map[string]*RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) PatternProperties(v map[string]*RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1279,7 +1279,7 @@ func (b *SchemaBulder) PatternProperties(v map[string]*RefOrSpec[Schema]) *Schem
 	return b
 }
 
-func (b *SchemaBulder) AddPatternProperty(name string, value *RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) AddPatternProperty(name string, value *RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1290,7 +1290,7 @@ func (b *SchemaBulder) AddPatternProperty(name string, value *RefOrSpec[Schema])
 	return b
 }
 
-func (b *SchemaBulder) AdditionalProperties(v *BoolOrSchema) *SchemaBulder {
+func (b *SchemaBuilder) AdditionalProperties(v *BoolOrSchema) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1298,7 +1298,7 @@ func (b *SchemaBulder) AdditionalProperties(v *BoolOrSchema) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) UnevaluatedProperties(v *BoolOrSchema) *SchemaBulder {
+func (b *SchemaBuilder) UnevaluatedProperties(v *BoolOrSchema) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1306,7 +1306,7 @@ func (b *SchemaBulder) UnevaluatedProperties(v *BoolOrSchema) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) PropertyNames(v *RefOrSpec[Schema]) *SchemaBulder {
+func (b *SchemaBuilder) PropertyNames(v *RefOrSpec[Schema]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1314,7 +1314,7 @@ func (b *SchemaBulder) PropertyNames(v *RefOrSpec[Schema]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) MinProperties(v int) *SchemaBulder {
+func (b *SchemaBuilder) MinProperties(v int) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1322,7 +1322,7 @@ func (b *SchemaBulder) MinProperties(v int) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) MaxProperties(v int) *SchemaBulder {
+func (b *SchemaBuilder) MaxProperties(v int) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1330,7 +1330,7 @@ func (b *SchemaBulder) MaxProperties(v int) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Required(v ...string) *SchemaBulder {
+func (b *SchemaBuilder) Required(v ...string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1338,7 +1338,7 @@ func (b *SchemaBulder) Required(v ...string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) AddRequired(v ...string) *SchemaBulder {
+func (b *SchemaBuilder) AddRequired(v ...string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1346,7 +1346,7 @@ func (b *SchemaBulder) AddRequired(v ...string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Discriminator(v *Discriminator) *SchemaBulder {
+func (b *SchemaBuilder) Discriminator(v *Discriminator) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1354,7 +1354,7 @@ func (b *SchemaBulder) Discriminator(v *Discriminator) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) XML(v *Extendable[XML]) *SchemaBulder {
+func (b *SchemaBuilder) XML(v *Extendable[XML]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1362,7 +1362,7 @@ func (b *SchemaBulder) XML(v *Extendable[XML]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) ExternalDocs(v *Extendable[ExternalDocs]) *SchemaBulder {
+func (b *SchemaBuilder) ExternalDocs(v *Extendable[ExternalDocs]) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1370,7 +1370,7 @@ func (b *SchemaBulder) ExternalDocs(v *Extendable[ExternalDocs]) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) Example(v any) *SchemaBulder {
+func (b *SchemaBuilder) Example(v any) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1378,7 +1378,7 @@ func (b *SchemaBulder) Example(v any) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) GoType(v string) *SchemaBulder {
+func (b *SchemaBuilder) GoType(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1386,7 +1386,7 @@ func (b *SchemaBulder) GoType(v string) *SchemaBulder {
 	return b
 }
 
-func (b *SchemaBulder) GoPackage(v string) *SchemaBulder {
+func (b *SchemaBuilder) GoPackage(v string) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}


### PR DESCRIPTION
Introduce ParseObject function to parse Go types into OpenAPI schema
representations, supporting structs, pointers, maps, slices, and primitives.
Handle tags for customizing schema fields, references, and metadata. This
enables automatic schema generation from Go types, improving integration
with OpenAPI components and reducing manual schema definitions.
