### PR TITLE
Use versions for checkout and setup-go actions

### DIFF
--- a/.github/workflows/code.yaml
+++ b/.github/workflows/code.yaml
@@ -28,9 +28,9 @@ jobs:
           - "1.23"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4.2.2 # immutable action, safe to use the versions
       - name: Install Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@v5.2.0 # immutable action, safe to use the versions
         with:
           go-version: ${{ matrix.go }}
       - name: gofmt


### PR DESCRIPTION
The actions are immutable. so it is safe to use the versions instead of hashtags