### PR TITLE
docs: update supported Go versions and copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Tools
+Copyright (c) 2021 SV Tools
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The implementation of OpenAPI v3.1 Specification for Go using generics.
 
 ## Supported Go versions:
 
+* v1.24
 * v1.23
 * v1.22
 * v1.21


### PR DESCRIPTION
Add Go v1.24 to the list of supported versions in README.md to reflect
compatibility with the latest Go release. Update the copyright holder
name in LICENSE from "Tools" to "SV Tools" for accuracy and proper
attribution.