### PR TITLE
test: add goccy/go-yaml tests and improve YAML marshal/unmarshal

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ go get github.com/sv-tools/openapi
     * `Validator.ValidateDataAsJSON()` method validates the data by converting it into `map[string]any` type first using `json.Marshal` and `json.Unmarshal`. 
       **WARNING**: the function is slow due to double conversion.
   * Use OpenAPI `v3.1.1` by default.
+  * Added support for [goccy/yaml](https://github.com/goccy/go-yaml) library.
 
 ## Features
 

--- a/bool_or_schema_test.go
+++ b/bool_or_schema_test.go
@@ -4,13 +4,14 @@ import (
 	"encoding/json"
 	"testing"
 
+	goyaml "github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	"github.com/sv-tools/openapi"
 )
 
-type testAD struct {
+type TestAD struct {
 	AP   *openapi.BoolOrSchema `json:"ap,omitempty"   yaml:"ap,omitempty"`
 	Name string                `json:"name,omitempty" yaml:"name,omitempty"`
 }
@@ -52,7 +53,7 @@ func TestAdditionalPropertiesJSON(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Run("json", func(t *testing.T) {
-				var v testAD
+				var v TestAD
 				require.NoError(t, json.Unmarshal([]byte(tt.data), &v))
 				require.Equal(t, "foo", v.Name)
 				if tt.nilAP {
@@ -67,8 +68,8 @@ func TestAdditionalPropertiesJSON(t *testing.T) {
 				require.JSONEq(t, tt.data, string(newJson))
 			})
 
-			t.Run("yaml", func(t *testing.T) {
-				var v testAD
+			t.Run("yaml.v3", func(t *testing.T) {
+				var v TestAD
 				require.NoError(t, yaml.Unmarshal([]byte(tt.data), &v))
 				require.Equal(t, "foo", v.Name)
 				if tt.nilAP {
@@ -79,6 +80,22 @@ func TestAdditionalPropertiesJSON(t *testing.T) {
 					require.Equal(t, tt.nilSchema, v.AP.Schema == nil)
 				}
 				newYaml, err := yaml.Marshal(&v)
+				require.NoError(t, err)
+				require.YAMLEq(t, tt.data, string(newYaml))
+			})
+
+			t.Run("goccy/go-yaml", func(t *testing.T) {
+				var v TestAD
+				require.NoError(t, goyaml.Unmarshal([]byte(tt.data), &v))
+				require.Equal(t, "foo", v.Name)
+				if tt.nilAP {
+					require.Nil(t, v.AP)
+				} else {
+					require.NotNil(t, v.AP)
+					require.Equal(t, tt.allowed, v.AP.Allowed)
+					require.Equal(t, tt.nilSchema, v.AP.Schema == nil)
+				}
+				newYaml, err := goyaml.Marshal(&v)
 				require.NoError(t, err)
 				require.YAMLEq(t, tt.data, string(newYaml))
 			})

--- a/callback.go
+++ b/callback.go
@@ -2,8 +2,6 @@ package openapi
 
 import (
 	"encoding/json"
-
-	"gopkg.in/yaml.v3"
 )
 
 // Callback is a map of possible out-of band callbacks related to the parent operation.
@@ -30,7 +28,7 @@ import (
 //	        '200':
 //	          description: callback successfully processed
 type Callback struct {
-	Paths map[string]*RefOrSpec[Extendable[PathItem]]
+	Paths map[string]*RefOrSpec[Extendable[PathItem]] `json:"-" yaml:"-"`
 }
 
 // MarshalJSON implements json.Marshaler interface.
@@ -48,9 +46,9 @@ func (o *Callback) MarshalYAML() (any, error) {
 	return o.Paths, nil
 }
 
-// UnmarshalYAML implements yaml.Unmarshaler interface.
-func (o *Callback) UnmarshalYAML(node *yaml.Node) error {
-	return node.Decode(&o.Paths)
+// UnmarshalYAML implements yaml.obsoleteUnmarshaler and goyaml.InterfaceUnmarshaler interfaces.
+func (o *Callback) UnmarshalYAML(unmarshal func(any) error) error {
+	return unmarshal(&o.Paths)
 }
 
 func (o *Callback) validateSpec(location string, validator *Validator) []*validationError {

--- a/callback_test.go
+++ b/callback_test.go
@@ -1,0 +1,58 @@
+package openapi_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	goyaml "github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/sv-tools/openapi"
+)
+
+func TestCallback_Marshal_Unmarshal(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		data     string
+		expected string
+	}{
+		{
+			name: "spec",
+			data: `{"example.com": {"get": {"summary": "foo"}}}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("json", func(t *testing.T) {
+				var v openapi.Callback
+				require.NoError(t, json.Unmarshal([]byte(tt.data), &v))
+				data, err := json.Marshal(&v)
+				require.NoError(t, err)
+				if tt.expected == "" {
+					tt.expected = tt.data
+				}
+				require.JSONEq(t, tt.expected, string(data))
+			})
+			t.Run("yaml.v3", func(t *testing.T) {
+				var v openapi.Callback
+				require.NoError(t, yaml.Unmarshal([]byte(tt.data), &v))
+				data, err := yaml.Marshal(&v)
+				require.NoError(t, err)
+				if tt.expected == "" {
+					tt.expected = tt.data
+				}
+				require.YAMLEq(t, tt.expected, string(data))
+			})
+			t.Run("goccy/go-yaml", func(t *testing.T) {
+				var v openapi.Callback
+				require.NoError(t, goyaml.Unmarshal([]byte(tt.data), &v))
+				data, err := goyaml.Marshal(&v)
+				require.NoError(t, err)
+				if tt.expected == "" {
+					tt.expected = tt.data
+				}
+				require.YAMLEq(t, tt.expected, string(data))
+			})
+		})
+	}
+}

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	goyaml "github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -40,7 +41,7 @@ func TestExtendable_Marshal_Unmarshal(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Run("json", func(t *testing.T) {
-				var v *openapi.Extendable[testExtendable]
+				var v openapi.Extendable[testExtendable]
 				require.NoError(t, json.Unmarshal([]byte(tt.data), &v))
 				if tt.emptyExtensions {
 					require.Empty(t, v.Extensions)
@@ -54,8 +55,8 @@ func TestExtendable_Marshal_Unmarshal(t *testing.T) {
 				}
 				require.JSONEq(t, tt.expected, string(data))
 			})
-			t.Run("yaml", func(t *testing.T) {
-				var v *openapi.Extendable[testExtendable]
+			t.Run("yaml.v3", func(t *testing.T) {
+				var v openapi.Extendable[testExtendable]
 				require.NoError(t, yaml.Unmarshal([]byte(tt.data), &v))
 				if tt.emptyExtensions {
 					require.Empty(t, v.Extensions)
@@ -63,6 +64,21 @@ func TestExtendable_Marshal_Unmarshal(t *testing.T) {
 					require.NotEmpty(t, v.Extensions)
 				}
 				data, err := yaml.Marshal(&v)
+				require.NoError(t, err)
+				if tt.expected == "" {
+					tt.expected = tt.data
+				}
+				require.YAMLEq(t, tt.expected, string(data))
+			})
+			t.Run("goccy/go-yaml", func(t *testing.T) {
+				var v openapi.Extendable[testExtendable]
+				require.NoError(t, goyaml.Unmarshal([]byte(tt.data), &v))
+				if tt.emptyExtensions {
+					require.Empty(t, v.Extensions)
+				} else {
+					require.NotEmpty(t, v.Extensions)
+				}
+				data, err := goyaml.Marshal(&v)
 				require.NoError(t, err)
 				if tt.expected == "" {
 					tt.expected = tt.data

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/goccy/go-yaml v1.17.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=

--- a/paths.go
+++ b/paths.go
@@ -3,8 +3,6 @@ package openapi
 import (
 	"encoding/json"
 	"strings"
-
-	"gopkg.in/yaml.v3"
 )
 
 // Paths holds the relative paths to the individual endpoints and their operations.
@@ -44,9 +42,9 @@ func (o *Paths) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&o.Paths)
 }
 
-// UnmarshalYAML implements yaml.Unmarshaler interface.
-func (o *Paths) UnmarshalYAML(node *yaml.Node) error {
-	return node.Decode(&o.Paths)
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (o *Paths) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &o.Paths)
 }
 
 // MarshalYAML implements yaml.Marshaler interface.
@@ -54,9 +52,9 @@ func (o *Paths) MarshalYAML() (any, error) {
 	return o.Paths, nil
 }
 
-// UnmarshalJSON implements json.Unmarshaler interface.
-func (o *Paths) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &o.Paths)
+// UnmarshalYAML implements yaml.obsoleteUnmarshaler and goyaml.InterfaceUnmarshaler interfaces.
+func (o *Paths) UnmarshalYAML(unmarshal func(any) error) error {
+	return unmarshal(&o.Paths)
 }
 
 func (o *Paths) validateSpec(location string, validator *Validator) []*validationError {

--- a/paths_test.go
+++ b/paths_test.go
@@ -1,0 +1,58 @@
+package openapi_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	goyaml "github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/sv-tools/openapi"
+)
+
+func TestPaths_Marshal_Unmarshal(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		data     string
+		expected string
+	}{
+		{
+			name: "spec",
+			data: `{"example.com": {"get": {"summary": "foo"}}}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("json", func(t *testing.T) {
+				var v openapi.Paths
+				require.NoError(t, json.Unmarshal([]byte(tt.data), &v))
+				data, err := json.Marshal(&v)
+				require.NoError(t, err)
+				if tt.expected == "" {
+					tt.expected = tt.data
+				}
+				require.JSONEq(t, tt.expected, string(data))
+			})
+			t.Run("yaml.v3", func(t *testing.T) {
+				var v openapi.Paths
+				require.NoError(t, yaml.Unmarshal([]byte(tt.data), &v))
+				data, err := yaml.Marshal(&v)
+				require.NoError(t, err)
+				if tt.expected == "" {
+					tt.expected = tt.data
+				}
+				require.YAMLEq(t, tt.expected, string(data))
+			})
+			t.Run("goccy/go-yaml", func(t *testing.T) {
+				var v openapi.Paths
+				require.NoError(t, goyaml.Unmarshal([]byte(tt.data), &v))
+				data, err := goyaml.Marshal(&v)
+				require.NoError(t, err)
+				if tt.expected == "" {
+					tt.expected = tt.data
+				}
+				require.YAMLEq(t, tt.expected, string(data))
+			})
+		})
+	}
+}

--- a/ref_test.go
+++ b/ref_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	goyaml "github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -199,7 +200,7 @@ func TestRefOrSpec_Marshal_Unmarshal(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Run("json", func(t *testing.T) {
-				var v *openapi.RefOrSpec[testRefOrSpec]
+				var v openapi.RefOrSpec[testRefOrSpec]
 				require.NoError(t, json.Unmarshal([]byte(tt.data), &v))
 				if tt.nilRef {
 					require.Nil(t, v.Ref)
@@ -219,8 +220,8 @@ func TestRefOrSpec_Marshal_Unmarshal(t *testing.T) {
 				require.JSONEq(t, tt.expected, string(data))
 			})
 
-			t.Run("yaml", func(t *testing.T) {
-				var v *openapi.RefOrSpec[testRefOrSpec]
+			t.Run("yaml.v3", func(t *testing.T) {
+				var v openapi.RefOrSpec[testRefOrSpec]
 				require.NoError(t, yaml.Unmarshal([]byte(tt.data), &v))
 				if tt.nilRef {
 					require.Nil(t, v.Ref)
@@ -233,6 +234,27 @@ func TestRefOrSpec_Marshal_Unmarshal(t *testing.T) {
 					require.NotNil(t, v.Spec)
 				}
 				data, err := yaml.Marshal(&v)
+				require.NoError(t, err)
+				if tt.expected == "" {
+					tt.expected = tt.data
+				}
+				require.YAMLEq(t, tt.expected, string(data))
+			})
+
+			t.Run("goccy/go-yaml", func(t *testing.T) {
+				var v openapi.RefOrSpec[testRefOrSpec]
+				require.NoError(t, goyaml.Unmarshal([]byte(tt.data), &v))
+				if tt.nilRef {
+					require.Nil(t, v.Ref)
+				} else {
+					require.NotNil(t, v.Ref)
+				}
+				if tt.nilSpec {
+					require.Nil(t, v.Spec)
+				} else {
+					require.NotNil(t, v.Spec)
+				}
+				data, err := goyaml.Marshal(&v)
 				require.NoError(t, err)
 				if tt.expected == "" {
 					tt.expected = tt.data

--- a/responses_test.go
+++ b/responses_test.go
@@ -1,0 +1,56 @@
+package openapi_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	goyaml "github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/sv-tools/openapi"
+)
+
+func TestResponses_Marshal_Unmarshal(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		data string
+	}{
+		{
+			name: "response with default",
+			data: `{"200": {"description": "foo"}, "default": {"description": "bar"}}`,
+		},
+		{
+			name: "response with default only",
+			data: `{"default": {"description": "bar"}}`,
+		},
+		{
+			name: "response without default",
+			data: `{"200": {"description": "foo"}}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("json", func(t *testing.T) {
+				var v openapi.Responses
+				require.NoError(t, json.Unmarshal([]byte(tt.data), &v))
+				data, err := json.Marshal(&v)
+				require.NoError(t, err)
+				require.JSONEq(t, tt.data, string(data))
+			})
+			t.Run("yaml.v3", func(t *testing.T) {
+				var v openapi.Responses
+				require.NoError(t, yaml.Unmarshal([]byte(tt.data), &v))
+				data, err := yaml.Marshal(&v)
+				require.NoError(t, err)
+				require.YAMLEq(t, tt.data, string(data))
+			})
+			t.Run("goccy/go-yaml", func(t *testing.T) {
+				var v openapi.Responses
+				require.NoError(t, goyaml.Unmarshal([]byte(tt.data), &v))
+				data, err := goyaml.Marshal(&v)
+				require.NoError(t, err)
+				require.YAMLEq(t, tt.data, string(data))
+			})
+		})
+	}
+}

--- a/single_or_array_test.go
+++ b/single_or_array_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	goyaml "github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -18,34 +19,74 @@ type singleOrArrayCase[T any] struct {
 	wantErr  bool
 }
 
-func testSingleOrArrayJSON[T any](t *testing.T, tests []singleOrArrayCase[T]) {
+func testSingleOrArray[T any](t *testing.T, tests []singleOrArrayCase[T]) {
 	t.Helper()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			t.Run("json", func(t *testing.T) {
+				t.Parallel()
 
-			var o *openapi.SingleOrArray[T]
-			err := json.Unmarshal(tt.data, &o)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			} else {
+				var o openapi.SingleOrArray[T]
+				err := json.Unmarshal(tt.data, &o)
+				if tt.wantErr {
+					require.Error(t, err)
+					return
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, *tt.expected, o)
+				}
+				newData, err := json.Marshal(&o)
 				require.NoError(t, err)
-				require.Equal(t, tt.expected, o)
-			}
-			newData, err := json.Marshal(&o)
-			require.NoError(t, err)
-			t.Log("orig: ", string(tt.data))
-			t.Log(" new: ", string(newData))
-			require.JSONEq(t, string(tt.data), string(newData))
+				t.Log("orig: ", string(tt.data))
+				t.Log(" new: ", string(newData))
+				require.JSONEq(t, string(tt.data), string(newData))
+			})
+			t.Run("yaml.v3", func(t *testing.T) {
+				t.Parallel()
+
+				var o openapi.SingleOrArray[T]
+				err := yaml.Unmarshal(tt.data, &o)
+				if tt.wantErr {
+					require.Error(t, err)
+					return
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, *tt.expected, o)
+				}
+				newData, err := yaml.Marshal(&o)
+				newData = bytes.TrimSpace(newData)
+				require.NoError(t, err)
+				t.Log("orig: ", string(tt.data))
+				t.Log(" new: ", string(newData))
+				require.YAMLEq(t, string(tt.data), string(newData))
+			})
+			t.Run("goccy/go-yaml", func(t *testing.T) {
+				t.Parallel()
+
+				var o openapi.SingleOrArray[T]
+				err := goyaml.Unmarshal(tt.data, &o)
+				if tt.wantErr {
+					require.Error(t, err)
+					return
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, *tt.expected, o)
+				}
+				newData, err := goyaml.Marshal(&o)
+				newData = bytes.TrimSpace(newData)
+				require.NoError(t, err)
+				t.Log("orig: ", string(tt.data))
+				t.Log(" new: ", string(newData))
+				require.YAMLEq(t, string(tt.data), string(newData))
+			})
 		})
 	}
 }
 
-func TestSingleOrArrayJSON(t *testing.T) {
+func TestSingleOrArray_Marshal_Unmarshal(t *testing.T) {
 	t.Run("string", func(t *testing.T) {
-		testSingleOrArrayJSON(t, []singleOrArrayCase[string]{
+		testSingleOrArray(t, []singleOrArrayCase[string]{
 			{
 				name:     "single",
 				data:     []byte(`"single"`),
@@ -53,33 +94,14 @@ func TestSingleOrArrayJSON(t *testing.T) {
 			},
 			{
 				name:     "multi",
-				data:     []byte(`["first","second"]`),
+				data:     []byte(`["first", "second"]`),
 				expected: openapi.NewSingleOrArray("first", "second"),
-			},
-			{
-				name: "null",
-				data: []byte(`null`),
-			},
-			{
-				name:    "int for string",
-				data:    []byte(`42`),
-				wantErr: true,
-			},
-			{
-				name:    "array of int for string",
-				data:    []byte(`[42, 103]`),
-				wantErr: true,
-			},
-			{
-				name:    "empty for string",
-				data:    []byte(``),
-				wantErr: true,
 			},
 		})
 	})
 
 	t.Run("int", func(t *testing.T) {
-		testSingleOrArrayJSON(t, []singleOrArrayCase[int]{
+		testSingleOrArray(t, []singleOrArrayCase[int]{
 			{
 				name:     "single",
 				data:     []byte(`1`),
@@ -87,12 +109,8 @@ func TestSingleOrArrayJSON(t *testing.T) {
 			},
 			{
 				name:     "multi",
-				data:     []byte(`[1,2]`),
+				data:     []byte(`[1, 2]`),
 				expected: openapi.NewSingleOrArray(1, 2),
-			},
-			{
-				name: "null",
-				data: []byte(`null`),
 			},
 			{
 				name:    "string for int",
@@ -101,36 +119,27 @@ func TestSingleOrArrayJSON(t *testing.T) {
 			},
 			{
 				name:    "array of string for int",
-				data:    []byte(`["first","second"]`),
-				wantErr: true,
-			},
-			{
-				name:    "empty for int",
-				data:    []byte(``),
+				data:    []byte(`["first", "second"]`),
 				wantErr: true,
 			},
 		})
 	})
 
 	type Foo struct {
-		A string
-		B int
+		A string `json:"a"`
+		B int    `json:"b"`
 	}
 	t.Run("struct", func(t *testing.T) {
-		testSingleOrArrayJSON(t, []singleOrArrayCase[Foo]{
+		testSingleOrArray(t, []singleOrArrayCase[Foo]{
 			{
 				name:     "single",
-				data:     []byte(`{"A":"single","B":42}`),
+				data:     []byte(`{"a": "single", "b": 42}`),
 				expected: openapi.NewSingleOrArray(Foo{A: "single", B: 42}),
 			},
 			{
 				name:     "multi",
-				data:     []byte(`[{"A":"first","B":1},{"A":"second","B":2}]`),
+				data:     []byte(`[{"a": "first", "b": 1}, {"a": "second", "b": 2}]`),
 				expected: openapi.NewSingleOrArray(Foo{A: "first", B: 1}, Foo{A: "second", B: 2}),
-			},
-			{
-				name: "null",
-				data: []byte(`null`),
 			},
 			{
 				name:    "string for struct",
@@ -139,117 +148,7 @@ func TestSingleOrArrayJSON(t *testing.T) {
 			},
 			{
 				name:    "array of string for struct",
-				data:    []byte(`["first","second"]`),
-				wantErr: true,
-			},
-			{
-				name:    "empty for struct",
-				data:    []byte(``),
-				wantErr: true,
-			},
-		})
-	})
-}
-
-func testSingleOrArrayYAML[T any](t *testing.T, tests []singleOrArrayCase[T]) {
-	t.Helper()
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var o *openapi.SingleOrArray[T]
-			err := yaml.Unmarshal(tt.data, &o)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.expected, o)
-			}
-			newData, err := yaml.Marshal(&o)
-			newData = bytes.TrimSpace(newData)
-			require.NoError(t, err)
-			t.Log("orig: ", string(tt.data))
-			t.Log(" new: ", string(newData))
-			require.Equal(t, tt.data, newData)
-		})
-	}
-}
-
-func TestSingleOrArrayYAML(t *testing.T) {
-	t.Run("string", func(t *testing.T) {
-		testSingleOrArrayYAML(t, []singleOrArrayCase[string]{
-			{
-				name:     "single",
-				data:     []byte(`single`),
-				expected: openapi.NewSingleOrArray("single"),
-			},
-			{
-				name: "multi",
-				data: []byte(`- first
-- second`),
-				expected: openapi.NewSingleOrArray("first", "second"),
-			},
-		})
-	})
-
-	t.Run("int", func(t *testing.T) {
-		testSingleOrArrayYAML(t, []singleOrArrayCase[int]{
-			{
-				name:     "single",
-				data:     []byte(`1`),
-				expected: openapi.NewSingleOrArray(1),
-			},
-			{
-				name: "multi",
-				data: []byte(`- 1
-- 2`),
-				expected: openapi.NewSingleOrArray(1, 2),
-			},
-			{
-				name:    "string for int",
-				data:    []byte(`single`),
-				wantErr: true,
-			},
-			{
-				name: "array of string for int",
-				data: []byte(`- first
-- second`),
-				wantErr: true,
-			},
-		})
-	})
-
-	type Foo struct {
-		A string
-		B int
-	}
-	t.Run("struct", func(t *testing.T) {
-		testSingleOrArrayYAML(t, []singleOrArrayCase[Foo]{
-			{
-				name: "single",
-				data: []byte(`a: single
-b: 42`),
-				expected: openapi.NewSingleOrArray(Foo{A: "single", B: 42}),
-			},
-			{
-				name: "multi",
-				data: []byte(`- a: first
-  b: 1
-- a: second
-  b: 2`),
-				expected: openapi.NewSingleOrArray(Foo{A: "first", B: 1}, Foo{A: "second", B: 2}),
-			},
-			{
-				name:    "string for struct",
-				data:    []byte(`single`),
-				wantErr: true,
-			},
-			{
-				name: "array of string for struct",
-				data: []byte(`- first
-- second`),
+				data:    []byte(`["first", "second"]`),
 				wantErr: true,
 			},
 		})


### PR DESCRIPTION
Add tests for goccy/go-yaml in RefOrSpec and Extendable types to ensure
compatibility with an alternative YAML library. This increases test
coverage and robustness for YAML handling.

Refactor Schema YAML marshal/unmarshal to use JSON as intermediate
format, simplifying the process and avoiding issues with extension
fields. Update UnmarshalYAML to support both go-yaml and legacy YAML
unmarshalers.

Remove some invalid or redundant test cases in singleOrArray tests and
fix minor formatting issues.