### PR TITLE
feat: Integrate GolangCi linter

### DIFF
--- a/.github/workflows/code.yaml
+++ b/.github/workflows/code.yaml
@@ -25,19 +25,15 @@ jobs:
       - uses: actions/setup-go@v5.5.0 # immutable action, safe to use the versions
         with:
           go-version-file: go.mod
-      - name: gofmt
-        run: diff -u <(echo -n) <(gofmt -l . )
-      - name: show diff
-        if: ${{ failure() }}
-        run: git diff
-      - run: go vet ./...
+      - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          version: latest
 
   UnitTestJob:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         go:
-          - "1.21"
           - "1.22"
           - "1.23"
           - "1.24"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,106 @@
+version: "2"
+
+linters:
+  default: none
+
+  enable: # keep in ascending order
+    - asasalint
+    - asciicheck
+    - bodyclose
+    - canonicalheader
+    - containedctx
+    - contextcheck
+    - copyloopvar
+    - decorder
+    - dogsled
+    - dupword
+    - durationcheck
+    - err113
+    - errcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - exptostd
+    - fatcontext
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - goconst
+    - gocritic
+    - goprintffuncname
+    - gosec
+    - gosmopolitan
+    - govet
+    - iface
+    - inamedparam
+    - ineffassign
+    - intrange
+    - makezero
+    - mirror
+    - misspell
+    - musttag
+    - nestif
+    - nilerr
+    - nilnesserr
+    - nilnil
+    - noctx
+    - nolintlint
+    - perfsprint
+    - prealloc
+    - predeclared
+    - reassign
+    - recvcheck
+    - sloglint
+    - staticcheck
+    - tagalign
+    - testableexamples
+    - testifylint
+    - testpackage
+    - thelper
+    - tparallel
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - usetesting
+    - wastedassign
+    - whitespace
+
+  settings:
+    misspell:
+      locale: US
+    nestif:
+      min-complexity: 12
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    prealloc:
+      for-loops: true
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      disabled-checks:
+        - whyNoLint
+
+  exclusions:
+    warn-unused: true
+    rules:
+      - path: _test\.go
+        linters:
+          - gosec
+
+formatters:
+  enable:
+    - gci
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/sv-tools/openapi)
+    gofumpt:
+      extra-rules: true

--- a/bool_or_schema_test.go
+++ b/bool_or_schema_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 type testAD struct {
-	AP   *openapi.BoolOrSchema `json:"ap,omitempty" yaml:"ap,omitempty"`
+	AP   *openapi.BoolOrSchema `json:"ap,omitempty"   yaml:"ap,omitempty"`
 	Name string                `json:"name,omitempty" yaml:"name,omitempty"`
 }
 

--- a/callback.go
+++ b/callback.go
@@ -2,6 +2,7 @@ package openapi
 
 import (
 	"encoding/json"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -57,7 +58,7 @@ func (o *Callback) validateSpec(location string, validator *Validator) []*valida
 	for k, v := range o.Paths {
 		errs = append(errs, v.validateSpec(joinLoc(location, k), validator)...)
 	}
-	return nil
+	return errs
 }
 
 func (o *Callback) Add(expression string, item *RefOrSpec[Extendable[PathItem]]) *Callback {

--- a/components.go
+++ b/components.go
@@ -164,7 +164,7 @@ func (o *Components) Add(name string, v any) *Components {
 	return o
 }
 
-var namePattern = regexp.MustCompile(`^[a-zA-Z0-9\.\-_]+$`)
+var namePattern = regexp.MustCompile(`^[a-zA-Z0-9.\-_]+$`)
 
 func (o *Components) validateSpec(location string, validator *Validator) []*validationError {
 	var errs []*validationError

--- a/components_test.go
+++ b/components_test.go
@@ -11,16 +11,20 @@ import (
 func TestComponents_Add(t *testing.T) {
 	for _, tt := range []struct {
 		name   string
-		create func() (string, any)
+		create func(tb testing.TB) (string, any)
 		check  func(tb testing.TB, c *openapi.Components)
 	}{
 		{
 			name: "schema ref or spec",
-			create: func() (string, any) {
+			create: func(tb testing.TB) (string, any) {
+				tb.Helper()
+
 				o := openapi.NewSchemaBuilder().Title("test").Build()
 				return "testSchema", o
 			},
 			check: func(tb testing.TB, c *openapi.Components) {
+				tb.Helper()
+
 				require.Len(tb, c.Schemas, 1)
 				require.NotNil(tb, c.Schemas["testSchema"])
 				require.NotNil(tb, c.Schemas["testSchema"].Spec)
@@ -29,11 +33,15 @@ func TestComponents_Add(t *testing.T) {
 		},
 		{
 			name: "response spec",
-			create: func() (string, any) {
+			create: func(tb testing.TB) (string, any) {
+				tb.Helper()
+
 				o := openapi.NewResponseBuilder().Description("test").Build()
 				return "testResponse", o
 			},
 			check: func(tb testing.TB, c *openapi.Components) {
+				tb.Helper()
+
 				require.Len(tb, c.Responses, 1)
 				require.NotNil(tb, c.Responses["testResponse"])
 				require.NotNil(tb, c.Responses["testResponse"].Spec)
@@ -43,11 +51,15 @@ func TestComponents_Add(t *testing.T) {
 		},
 		{
 			name: "parameter spec",
-			create: func() (string, any) {
+			create: func(tb testing.TB) (string, any) {
+				tb.Helper()
+
 				o := openapi.NewParameterBuilder().Description("test").Build()
 				return "testParameter", o
 			},
 			check: func(tb testing.TB, c *openapi.Components) {
+				tb.Helper()
+
 				require.Len(tb, c.Parameters, 1)
 				require.NotNil(tb, c.Parameters["testParameter"])
 				require.NotNil(tb, c.Parameters["testParameter"].Spec)
@@ -57,11 +69,15 @@ func TestComponents_Add(t *testing.T) {
 		},
 		{
 			name: "examples spec",
-			create: func() (string, any) {
+			create: func(tb testing.TB) (string, any) {
+				tb.Helper()
+
 				o := openapi.NewExampleBuilder().Description("test").Build()
 				return "testExamples", o
 			},
 			check: func(tb testing.TB, c *openapi.Components) {
+				tb.Helper()
+
 				require.Len(tb, c.Examples, 1)
 				require.NotNil(tb, c.Examples["testExamples"])
 				require.NotNil(tb, c.Examples["testExamples"].Spec)
@@ -71,11 +87,15 @@ func TestComponents_Add(t *testing.T) {
 		},
 		{
 			name: "request body spec",
-			create: func() (string, any) {
+			create: func(tb testing.TB) (string, any) {
+				tb.Helper()
+
 				o := openapi.NewRequestBodyBuilder().Description("test").Build()
 				return "testRequestBodies", o
 			},
 			check: func(tb testing.TB, c *openapi.Components) {
+				tb.Helper()
+
 				require.Len(tb, c.RequestBodies, 1)
 				require.NotNil(tb, c.RequestBodies["testRequestBodies"])
 				require.NotNil(tb, c.RequestBodies["testRequestBodies"].Spec)
@@ -85,11 +105,15 @@ func TestComponents_Add(t *testing.T) {
 		},
 		{
 			name: "headers spec",
-			create: func() (string, any) {
+			create: func(tb testing.TB) (string, any) {
+				tb.Helper()
+
 				o := openapi.NewHeaderBuilder().Description("test").Build()
 				return "testHeader", o
 			},
 			check: func(tb testing.TB, c *openapi.Components) {
+				tb.Helper()
+
 				require.Len(tb, c.Headers, 1)
 				require.NotNil(tb, c.Headers["testHeader"])
 				require.NotNil(tb, c.Headers["testHeader"].Spec)
@@ -99,13 +123,17 @@ func TestComponents_Add(t *testing.T) {
 		},
 		{
 			name: "security schemes spec",
-			create: func() (string, any) {
+			create: func(tb testing.TB) (string, any) {
+				tb.Helper()
+
 				o := &openapi.SecurityScheme{
 					Description: "test",
 				}
 				return "testSecurityScheme", openapi.NewRefOrExtSpec[openapi.SecurityScheme](o)
 			},
 			check: func(tb testing.TB, c *openapi.Components) {
+				tb.Helper()
+
 				require.Len(tb, c.SecuritySchemes, 1)
 				require.NotNil(tb, c.SecuritySchemes["testSecurityScheme"])
 				require.NotNil(tb, c.SecuritySchemes["testSecurityScheme"].Spec)
@@ -115,11 +143,15 @@ func TestComponents_Add(t *testing.T) {
 		},
 		{
 			name: "link spec",
-			create: func() (string, any) {
+			create: func(tb testing.TB) (string, any) {
+				tb.Helper()
+
 				o := openapi.NewLinkBuilder().Description("test").Build()
 				return "testLink", o
 			},
 			check: func(tb testing.TB, c *openapi.Components) {
+				tb.Helper()
+
 				require.Len(tb, c.Links, 1)
 				require.NotNil(tb, c.Links["testLink"])
 				require.NotNil(tb, c.Links["testLink"].Spec)
@@ -129,7 +161,9 @@ func TestComponents_Add(t *testing.T) {
 		},
 		{
 			name: "callback spec",
-			create: func() (string, any) {
+			create: func(tb testing.TB) (string, any) {
+				tb.Helper()
+
 				o := openapi.NewCallbackBuilder().AddPathItem(
 					"testPath",
 					openapi.NewPathItemBuilder().Description("test").Build(),
@@ -137,6 +171,8 @@ func TestComponents_Add(t *testing.T) {
 				return "testCallback", o
 			},
 			check: func(tb testing.TB, c *openapi.Components) {
+				tb.Helper()
+
 				require.Len(tb, c.Callbacks, 1)
 				require.NotNil(tb, c.Callbacks["testCallback"])
 				require.NotNil(tb, c.Callbacks["testCallback"].Spec)
@@ -151,11 +187,15 @@ func TestComponents_Add(t *testing.T) {
 		},
 		{
 			name: "path item spec",
-			create: func() (string, any) {
+			create: func(tb testing.TB) (string, any) {
+				tb.Helper()
+
 				o := openapi.NewPathItemBuilder().Description("test").Build()
 				return "testPathItem", o
 			},
 			check: func(tb testing.TB, c *openapi.Components) {
+				tb.Helper()
+
 				require.Len(tb, c.Paths, 1)
 				require.NotNil(tb, c.Paths["testPathItem"])
 				require.NotNil(tb, c.Paths["testPathItem"].Spec)
@@ -165,7 +205,7 @@ func TestComponents_Add(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			name, obj := tt.create()
+			name, obj := tt.create(t)
 			tt.check(t, (&openapi.Components{}).Add(name, obj))
 		})
 	}

--- a/contact.go
+++ b/contact.go
@@ -20,7 +20,7 @@ type Contact struct {
 	Email string `json:"email,omitempty" yaml:"email,omitempty"`
 }
 
-func (o *Contact) validateSpec(location string, validator *Validator) []*validationError {
+func (o *Contact) validateSpec(location string, _ *Validator) []*validationError {
 	var errs []*validationError
 	if err := checkURL(o.URL); err != nil {
 		errs = append(errs, newValidationError(joinLoc(location, "url"), err))

--- a/example.go
+++ b/example.go
@@ -47,7 +47,7 @@ type Example struct {
 	ExternalValue string `json:"externalValue,omitempty" yaml:"externalValue,omitempty"`
 }
 
-func (o *Example) validateSpec(location string, validator *Validator) []*validationError {
+func (o *Example) validateSpec(location string, _ *Validator) []*validationError {
 	var errs []*validationError
 	if o.Value != nil && o.ExternalValue != "" {
 		errs = append(errs, newValidationError(joinLoc(location, "value&externalValue"), ErrMutuallyExclusive))

--- a/external-docs.go
+++ b/external-docs.go
@@ -18,7 +18,7 @@ type ExternalDocs struct {
 	URL string `json:"url" yaml:"url"`
 }
 
-func (o *ExternalDocs) validateSpec(location string, validator *Validator) []*validationError {
+func (o *ExternalDocs) validateSpec(location string, _ *Validator) []*validationError {
 	var errs []*validationError
 	if o.URL == "" {
 		errs = append(errs, newValidationError(joinLoc(location, "url"), ErrRequired))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sv-tools/openapi
 
-go 1.21.0
+go 1.22.0
 
 retract v0.3.0 // due to a mistake, there is no real v0.3.0 release, it was pointed to v0.2.2 tag
 

--- a/license.go
+++ b/license.go
@@ -21,7 +21,7 @@ type License struct {
 	URL string `json:"url,omitempty" yaml:"url,omitempty"`
 }
 
-func (o *License) validateSpec(location string, validator *Validator) []*validationError {
+func (o *License) validateSpec(location string, _ *Validator) []*validationError {
 	var errs []*validationError
 	if o.Name == "" {
 		errs = append(errs, newValidationError(joinLoc(location, "name"), ErrRequired))

--- a/link.go
+++ b/link.go
@@ -92,7 +92,7 @@ func (o *Link) validateSpec(location string, validator *Validator) []*validation
 		}
 	}
 	// uncomment when JSONLookup is implemented
-	//if o.OperationRef != "" {
+	// if o.OperationRef != "" {
 	//	ref := NewRefOrExtSpec[Operation](o.OperationRef)
 	//	errs = append(errs, ref.validateSpec(joinLoc(location, "operationRef"), validator)...)
 	//}

--- a/operation.go
+++ b/operation.go
@@ -144,7 +144,6 @@ func (o *Operation) validateSpec(location string, validator *Validator) []*valid
 		for i, t := range o.Tags {
 			if !validator.opts.allowUndefinedTagsInOperation && !validator.visited[joinLoc("tags", t)] {
 				errs = append(errs, newValidationError(joinLoc(location, "tags", i), "'%s' not found", t))
-
 			}
 			validator.visited[joinLoc("tags", t, "used")] = true
 		}

--- a/responses.go
+++ b/responses.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var ResponseCodePattern = regexp.MustCompile(`^[1-5](?:[0-9]{2}|XX)$`)
+var ResponseCodePattern = regexp.MustCompile(`^[1-5](?:\d{2}|XX)$`)
 
 // Responses is a container for the expected responses of an operation.
 // The container maps a HTTP response code to the expected response.

--- a/security-requirement.go
+++ b/security-requirement.go
@@ -14,7 +14,7 @@ package openapi
 //	api_key: []
 type SecurityRequirement map[string][]string
 
-func (o *SecurityRequirement) validateSpec(path string, validator *Validator) []*validationError {
+func (o *SecurityRequirement) validateSpec(_ string, validator *Validator) []*validationError { //nolint: unparam // by design
 	for k := range *o {
 		validator.visited[joinLoc("#", "components", "securitySchemes", k)] = true
 	}

--- a/server_variable.go
+++ b/server_variable.go
@@ -18,7 +18,7 @@ type ServerVariable struct {
 	Enum []string `json:"enum,omitempty" yaml:"enum,omitempty"`
 }
 
-func (o *ServerVariable) validateSpec(location string, validator *Validator) []*validationError {
+func (o *ServerVariable) validateSpec(location string, _ *Validator) []*validationError {
 	var errs []*validationError
 	if o.Default == "" {
 		errs = append(errs, newValidationError(joinLoc(location, "default"), ErrRequired))

--- a/single_or_array_test.go
+++ b/single_or_array_test.go
@@ -19,8 +19,9 @@ type singleOrArrayCase[T any] struct {
 }
 
 func testSingleOrArrayJSON[T any](t *testing.T, tests []singleOrArrayCase[T]) {
+	t.Helper()
+
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -151,8 +152,9 @@ func TestSingleOrArrayJSON(t *testing.T) {
 }
 
 func testSingleOrArrayYAML[T any](t *testing.T, tests []singleOrArrayCase[T]) {
+	t.Helper()
+
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/types.go
+++ b/types.go
@@ -3,6 +3,7 @@ package openapi
 import (
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 const (
@@ -81,6 +82,22 @@ func getKind(v any) reflect.Kind {
 	return k
 }
 
+const unsupportedTypePrefix = "unsupported type: "
+
+type UnsupportedTypeError string
+
+func (e UnsupportedTypeError) Error() string {
+	return unsupportedTypePrefix + string(e)
+}
+
+func (e UnsupportedTypeError) Is(target error) bool {
+	return strings.HasPrefix(target.Error(), unsupportedTypePrefix)
+}
+
+func NewUnsupportedTypeError(v reflect.Kind) error {
+	return UnsupportedTypeError(fmt.Sprintf("%T", v))
+}
+
 func kindToType(k reflect.Kind) (string, error) {
 	switch k {
 	case reflect.String:
@@ -96,6 +113,6 @@ func kindToType(k reflect.Kind) (string, error) {
 	case reflect.Slice, reflect.Array:
 		return ArrayType, nil
 	default:
-		return "", fmt.Errorf("unsupported type: %s", k.String())
+		return "", NewUnsupportedTypeError(k)
 	}
 }

--- a/validation.go
+++ b/validation.go
@@ -40,7 +40,7 @@ func newValidationError(location string, err any, args ...any) *validationError 
 	case error:
 		return &validationError{location: location, err: e}
 	case string:
-		return &validationError{location: location, err: fmt.Errorf(e, args...)}
+		return &validationError{location: location, err: fmt.Errorf(e, args...)} //nolint:err113 // by design
 	default:
 		// unreachable
 		panic(fmt.Sprintf("unsupported error type: %T", e))
@@ -129,6 +129,9 @@ func NewValidator(spec *Extendable[OpenAPI], opts ...ValidationOption) (*Validat
 		return nil, fmt.Errorf("marshaling spec failed: %w", err)
 	}
 	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("unmarshaling spec failed: %w", err)
+	}
 	compiler := jsonschema.NewCompiler()
 	compiler.DefaultDraft(jsonschema.Draft2020)
 	if err := compiler.AddResource(specPrefix, doc); err != nil {

--- a/validation_test.go
+++ b/validation_test.go
@@ -278,6 +278,8 @@ func TestNewValidator(t *testing.T) {
 }
 
 func TestValidator_ValidateData(t *testing.T) {
+	t.Parallel()
+
 	data, err := os.ReadFile(path.Join("testdata", "petstore.json"))
 	require.NoError(t, err)
 	var spec openapi.Extendable[openapi.OpenAPI]
@@ -321,7 +323,6 @@ func TestValidator_ValidateData(t *testing.T) {
 			compileError: "not found",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
- Add UnsupportedVersionError type for clearer OpenAPI version errors
- Refactor OpenAPI version validation to use the new error type
- Add //nolint directive to validation error creation to suppress err113 linter
- Update test helpers in components_test.go to accept testing.TB and call tb.Helper()
- Remove trailing blank line in operation tag validation for consistency
- Update go.mod to require Go 1.22
- Simplify Contact.validateSpec by ignoring validator parameter
- Minor cleanup in RefOrSpec switch case ordering and imports