### PR TITLE
chore(deps): group Dependabot updates for better management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      golangci-lint:
+        patterns:
+          - "golangci*"
+      ci:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add grouping for Dependabot updates in the configuration file.
Create separate groups for golangci-lint and CI-related dependencies.
This change improves update organization and allows targeted review
and merging of dependency updates on a weekly schedule.