### PR TITLE
chore(ci): Add Go 1.25

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,8 +6,3 @@ component_management:
         target: auto
         branches:
           - main
-  individual_components:
-    - component_id: spec
-      name: Specification
-      paths:
-        - spec/**

--- a/.github/workflows/code.yaml
+++ b/.github/workflows/code.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v5.0.0 # immutable action, safe to use the versions
       - uses: actions/setup-go@v5.5.0 # immutable action, safe to use the versions
         with:
-          go-version-file: go.mod
+          go-version-file: go.mod # use Go version from go.mod as minimum supported version
       - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: latest
@@ -37,6 +37,7 @@ jobs:
           - "1.22"
           - "1.23"
           - "1.24"
+          - "1.25"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5.0.0 # immutable action, safe to use the versions

--- a/README.md
+++ b/README.md
@@ -11,22 +11,23 @@ The implementation of OpenAPI v3.1 Specification for Go using generics.
 go get github.com/sv-tools/openapi
 ```
 
-## Supported Go versions:
+## Supported Go versions
 
+* v1.25
 * v1.24
 * v1.23
 * v1.22
 
-## Versions:
+## Versions
 
-* v0 - **Deprecated**. The initial version with the full implementation of the v3.1 Specification using generics. See `v0` branch.
-* v1 - The current version with the in-place validation of the specification. 
-  * The minimal version of Go is `v1.22`.
-  * Everything have been moved to root folder. So, the import path is `github.com/sv-tools/openapi`.
+* v0 - **Deprecated**. The initial version with the full implementation of the v3.1 Specification using generics. See the `v0` branch.
+* v1 - The current version with the in-place validation of the specification.
+  * The minimum version of Go is `v1.22`.
+  * Everything has been moved to the root folder. So, the import path is `github.com/sv-tools/openapi`.
   * Added `Validator` struct for validation of the specification and the data.
     * `Validator.ValidateSpec()` method validates the specification.
     * `Validator.ValidateData()` method validates the data.
-    * `Validator.ValidateDataAsJSON()` method validates the data by converting it into `map[string]any` type first using `json.Marshal` and `json.Unmarshal`. 
+    * `Validator.ValidateDataAsJSON()` method validates the data by converting it into `map[string]any` type first using `json.Marshal` and `json.Unmarshal`.
       **WARNING**: the function is slow due to double conversion.
   * Added `ParseObject` function to create `SchemaBuilder` by parsing an object.
     The function supports `json`, `yaml` and `openapi` field tags for the structs.
@@ -35,7 +36,8 @@ go get github.com/sv-tools/openapi
 ## Features
 
 * The official v3.0 and v3.1 [examples](https://github.com/OAI/OpenAPI-Specification/tree/main/examples) are tested.
-  In most cases v3.0 specification can be converted to v3.1 by changing the version's parameter only.
+  In most cases, the v3.0 specification can be converted to v3.1 by changing only the version parameter.
+
   ```diff
   @@ -1,4 +1,4 @@
   -openapi: "3.0.0"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sv-tools/openapi
 
-go 1.22.0
+go 1.22
 
 retract v0.3.0 // due to a mistake, there is no real v0.3.0 release, it was pointed to v0.2.2 tag
 


### PR DESCRIPTION
- Add Go 1.25 to the matrix and document using go.mod as the minimum
  supported Go version in the workflow. Update golangci-lint/action
  usage comment to use the immutable action reference.
- Normalize go.mod go directive from "1.22.0" to "1.22".
- Remove unused individual_components section from codecov config.
- Update README: list v1.25 as supported, fix several wording/grammar
  issues, and adjust formatting for clarity.

These changes modernize CI testing to include Go 1.25, clarify that the
workflow reads the minimum Go version from go.mod, and clean up docs and
coverage config for accuracy.