### PR TITLE
chore(de): switch to go.in/yaml v4 and update modules

### DIFF
--- a/bool_or_schema.go
+++ b/bool_or_schema.go
@@ -3,7 +3,7 @@ package openapi
 import (
 	"encoding/json"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // BoolOrSchema handles Boolean or Schema type.

--- a/bool_or_schema_test.go
+++ b/bool_or_schema_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/sv-tools/openapi"
 )

--- a/callback.go
+++ b/callback.go
@@ -3,7 +3,7 @@ package openapi
 import (
 	"encoding/json"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Callback is a map of possible out-of band callbacks related to the parent operation.

--- a/extensions.go
+++ b/extensions.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const ExtensionPrefix = "x-"

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/sv-tools/openapi"
 )

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,12 @@ retract v0.3.0 // due to a mistake, there is no real v0.3.0 release, it was poin
 require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.0
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v4 v4.0.0-rc.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEV
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/testify v1.11.0 h1:ib4sjIrwZKxE5u/Japgo/7SJV3PvgjGiRNAvTVGqQl8=
 github.com/stretchr/testify v1.11.0/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.yaml.in/yaml/v4 v4.0.0-rc.1 h1:4J1+yLKUIPGexM/Si+9d3pij4hdc7aGO04NhrElqXbY=
+go.yaml.in/yaml/v4 v4.0.0-rc.1/go.mod h1:CBdeces52/nUXndfQ5OY8GEQuNR9uEEOJPZj/Xq5IzU=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/paths.go
+++ b/paths.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Paths holds the relative paths to the individual endpoints and their operations.

--- a/ref.go
+++ b/ref.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Ref is a simple object to allow referencing other components in the OpenAPI document, internally and externally.

--- a/ref_test.go
+++ b/ref_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/sv-tools/openapi"
 )

--- a/responses.go
+++ b/responses.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"regexp"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 var ResponseCodePattern = regexp.MustCompile(`^[1-5](?:\d{2}|XX)$`)

--- a/schema.go
+++ b/schema.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const (

--- a/schema_test.go
+++ b/schema_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/sv-tools/openapi"
 )

--- a/single_or_array.go
+++ b/single_or_array.go
@@ -3,7 +3,7 @@ package openapi
 import (
 	"encoding/json"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // SingleOrArray holds list or single value

--- a/single_or_array_test.go
+++ b/single_or_array_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/sv-tools/openapi"
 )

--- a/validation_test.go
+++ b/validation_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/sv-tools/openapi"
 )


### PR DESCRIPTION
Replace imports of gopkg.in/yaml.v3 with the new module path
go.yaml.in/yaml/v4 across source and test files to prepare for the
yaml v4 release candidate. Update go.mod to require the v4 module
(rc.1) and add its checksums to go.sum.

This change modernizes YAML handling and aligns the project with the
v4 API while preserving compatibility with existing v3 artifacts.