### PR TITLE
feat(ci): dynamic Go version lookup

### DIFF
--- a/.github/workflows/code.yaml
+++ b/.github/workflows/code.yaml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       matrix: ${{ steps.versions.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5.0.0 # immutable action, safe to use the versions
       - uses: arnested/go-version-action@81f730770833dd20e6365d535ce7efcb3b136e7d #v1.1.21
         id: versions
 

--- a/.github/workflows/code.yaml
+++ b/.github/workflows/code.yaml
@@ -29,15 +29,22 @@ jobs:
         with:
           version: latest
 
+  GoVersions:
+    name: Lookup Go versions
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.versions.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: arnested/go-version-action@81f730770833dd20e6365d535ce7efcb3b136e7d #v1.1.21
+        id: versions
+
   UnitTestJob:
     runs-on: ubuntu-latest
+    needs: GoVersions
     strategy:
       matrix:
-        go:
-          - "1.22"
-          - "1.23"
-          - "1.24"
-          - "1.25"
+        go: ${{ fromJSON(needs.GoVersions.outputs.matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5.0.0 # immutable action, safe to use the versions


### PR DESCRIPTION
Introduce a new job (GoVersions) that uses arnested/go-version-action
to compute a matrix of supported Go versions and expose it as an output.
Make UnitTestJob depend on GoVersions and replace the hardcoded go matrix
with a dynamic matrix sourced from needs.GoVersions.outputs.matrix.

This removes the need to update the workflow whenever new Go versions are
added, ensuring the CI runs tests across the current set of supported
Go releases automatically.