### PR TITLE
chore(ci): pin actions to specific SHAs

### DIFF
--- a/.github/workflows/code.yaml
+++ b/.github/workflows/code.yaml
@@ -21,8 +21,8 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5.0.0 # immutable action, safe to use the versions
-      - uses: actions/setup-go@v5.5.0 # immutable action, safe to use the versions
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod # use Go version from go.mod as minimum supported version
       - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
@@ -35,7 +35,7 @@ jobs:
     outputs:
       matrix: ${{ steps.versions.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v5.0.0 # immutable action, safe to use the versions
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
       - uses: arnested/go-version-action@81f730770833dd20e6365d535ce7efcb3b136e7d #v1.1.21
         id: versions
 
@@ -46,10 +46,8 @@ jobs:
       matrix:
         go: ${{ fromJSON(needs.GoVersions.outputs.matrix) }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5.0.0 # immutable action, safe to use the versions
-      - name: Install Go
-        uses: actions/setup-go@v5.5.0 # immutable action, safe to use the versions
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ matrix.go }}
       - run: go install github.com/jstemmer/go-junit-report/v2@latest


### PR DESCRIPTION
Update GitHub Actions workflow to reference immutable commit
SHAs for actions/checkout and actions/setup-go instead of the
loose version tags. Replace v5.0.0/v5.5.0 references with the exact
commit SHAs used for v5.5.0 to ensure reproducible and auditable
CI runs. Keep golangci-lint and other actions unchanged.

This reduces supply-chain risk and guarantees the exact action
code used by the workflow.