### PR TITLE
fix(refs): improve spec-not-found error message for unexpected refs

### DIFF
--- a/ref.go
+++ b/ref.go
@@ -154,7 +154,7 @@ func (o *RefOrSpec[T]) getSpec(c *Extendable[Components], visited visitedObjects
 	case "paths":
 		ref = c.Spec.Paths[objName]
 	default:
-		return nil, NewSpecNotFoundError(fmt.Sprintf("unexpected component %q", ref), visited)
+		return nil, NewSpecNotFoundError(fmt.Sprintf("unexpected component name %q in ref %q", parts[0], o.Ref.Ref), visited)
 	}
 	obj, ok := ref.(*RefOrSpec[T])
 	if !ok {


### PR DESCRIPTION
Clarify error text when resolving component references by including
both the unexpected component name and the full ref string. Previously
the message only reported the component value, which made debugging less
informative when refs contain paths or complex identifiers. This change
adds the component name and the original ref to the error so callers
can more easily identify malformed or unexpected references.