### PR TITLE
feat(validation): add option to allow unused tags

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -138,9 +138,11 @@ func (o *OpenAPI) validateSpec(location string, validator *Validator) []*validat
 	}
 
 	// check for unused
-	for i, t := range o.Tags {
-		if !validator.visited[joinLoc("tags", t.Spec.Name, "used")] {
-			errs = append(errs, newValidationError(joinLoc(location, "tags", i), fmt.Errorf("'%s': %w", t.Spec.Name, ErrUnused)))
+	if !validator.opts.allowUnusedTags {
+		for i, t := range o.Tags {
+			if !validator.visited[joinLoc("tags", t.Spec.Name, "used")] {
+				errs = append(errs, newValidationError(joinLoc(location, "tags", i), fmt.Errorf("'%s': %w", t.Spec.Name, ErrUnused)))
+			}
 		}
 	}
 	if o.Components != nil && !validator.opts.allowUnusedComponents {

--- a/validation.go
+++ b/validation.go
@@ -113,7 +113,7 @@ const specPrefix = "http://spec"
 
 // NewValidator creates an instance of Validator struct.
 //
-// The function creates new jsonschema comppiler and adds the given spec to the compiler.
+// The function creates new jsonschema compiler and adds the given spec to the compiler.
 func NewValidator(spec *Extendable[OpenAPI], opts ...ValidationOption) (*Validator, error) {
 	options := &validationOptions{}
 	for _, opt := range opts {

--- a/validation_options.go
+++ b/validation_options.go
@@ -9,6 +9,7 @@ type validationOptions struct {
 	allowRequestBodyForDelete       bool
 	allowUndefinedTagsInOperation   bool
 	allowUnusedComponents           bool
+	allowUnusedTags                 bool
 	doNotValidateExamples           bool
 	doNotValidateDefaultValues      bool
 	validateDataAsJSON              bool
@@ -57,6 +58,13 @@ func AllowUndefinedTagsInOperation() ValidationOption {
 func AllowUnusedComponents() ValidationOption {
 	return func(v *validationOptions) {
 		v.allowUnusedComponents = true
+	}
+}
+
+// AllowUnusedTags is a validation option to allow declared but unused tags.
+func AllowUnusedTags() ValidationOption {
+	return func(v *validationOptions) {
+		v.allowUnusedTags = true
 	}
 }
 

--- a/validation_test.go
+++ b/validation_test.go
@@ -343,3 +343,27 @@ func TestValidator_ValidateData(t *testing.T) {
 		})
 	}
 }
+
+func TestValidator_UnusedTagsOption(t *testing.T) {
+	// Spec with one declared tag but unused
+	base := func() *openapi.Extendable[openapi.OpenAPI] {
+		return openapi.NewOpenAPIBuilder().
+			Info(openapi.NewInfoBuilder().Title("Spec").Version("1.0.0").Build()).
+			Paths(openapi.NewPaths()).
+			Tags(openapi.NewTagBuilder().Name("unused").Build()).
+			Build()
+	}
+
+	t.Run("unused tag error by default", func(t *testing.T) {
+		v, err := openapi.NewValidator(base())
+		require.NoError(t, err)
+		err = v.ValidateSpec()
+		require.ErrorContains(t, err, "unused")
+	})
+
+	t.Run("unused tag allowed when option set", func(t *testing.T) {
+		v, err := openapi.NewValidator(base(), openapi.AllowUnusedTags())
+		require.NoError(t, err)
+		require.NoError(t, v.ValidateSpec())
+	})
+}


### PR DESCRIPTION
Introduce allowTags to validation options and wire it into
OpenAPI validation to suppress errors for declared but unused tags.
Fix a small typo in the NewValidator doc comment ("compiler").
This enables callers to opt out of unused-tag checks while keeping
existing unused-components behavior unchanged.