### PR TITLE
test: add comprehensive schema validation unit tests

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -599,7 +599,7 @@ func (o *Schema) validateSpec(location string, validator *Validator) []*validati
 		for i, oi := range o.Enum {
 			for j, oj := range o.Enum[i+1:] {
 				if reflect.DeepEqual(oi, oj) {
-					errs = append(errs, newValidationError(joinLoc(location, "enum", j), "duplicate value found in enum: %v", oj))
+					errs = append(errs, newValidationError(joinLoc(location, "enum", i+1+j), "duplicate value found in enum: %v", oj))
 					break
 				}
 			}

--- a/schema.go
+++ b/schema.go
@@ -3,6 +3,7 @@ package openapi
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"reflect"
 	"regexp"
 	"strings"
@@ -24,7 +25,7 @@ const (
 // OAS also defers the definition of semantics to the application consuming the OpenAPI document.
 //
 // https://spec.openapis.org/oas/v3.1.1#schema-object
-// https://json-schema.org/understanding-json-schema/index.html
+// https://json-schema.org/understanding-json-schema/about
 type Schema struct {
 	// *** Core Fields ***
 
@@ -51,7 +52,7 @@ type Schema struct {
 	Defs          map[string]*RefOrSpec[Schema] `json:"$defs,omitempty"          yaml:"$defs,omitempty"`
 	DynamicRef    string                        `json:"$dynamicRef,omitempty"    yaml:"$dynamicRef,omitempty"`
 	Vocabulary    map[string]bool               `json:"$vocabulary,omitempty"    yaml:"$vocabulary,omitempty"`
-	DynamicAnchor string                        `json:"$dynamicAnchor,omitempty" yaml:"dynamicAnchor,omitempty"`
+	DynamicAnchor string                        `json:"$dynamicAnchor,omitempty" yaml:"$dynamicAnchor,omitempty"`
 	// https://json-schema.org/understanding-json-schema/reference/type#type-specific-keywords
 	Type *SingleOrArray[string] `json:"type,omitempty" yaml:"type,omitempty"`
 
@@ -74,7 +75,7 @@ type Schema struct {
 	// The const keyword is used to restrict a value to a single value.
 	//
 	// https://json-schema.org/understanding-json-schema/reference/const
-	Const string `json:"const,omitempty" yaml:"const,omitempty"`
+	Const any `json:"const,omitempty" yaml:"const,omitempty"`
 	// The $comment keyword is strictly intended for adding comments to a schema.
 	// Its value must always be a string.
 	// Unlike the annotations title, description, and examples, JSON schema implementations aren’t allowed
@@ -183,15 +184,15 @@ type Schema struct {
 	// It may be set to any positive number.
 	//
 	// https://json-schema.org/understanding-json-schema/reference/numeric.html#multiples
-	MultipleOf *int `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+	MultipleOf *float64 `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
 	// x ≥ minimum
-	Minimum *int `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	Minimum *float64 `json:"minimum,omitempty" yaml:"minimum,omitempty"`
 	// x > exclusiveMinimum
-	ExclusiveMinimum *int `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+	ExclusiveMinimum *float64 `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
 	// x ≤ maximum
-	Maximum *int `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	Maximum *float64 `json:"maximum,omitempty" yaml:"maximum,omitempty"`
 	// x < exclusiveMaximum
-	ExclusiveMaximum *int `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+	ExclusiveMaximum *float64 `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
 
 	// *** String Type Fields ***
 	//
@@ -526,9 +527,11 @@ func (o *Schema) validateSpec(location string, validator *Validator) []*validati
 		}
 	}
 
-	// JsonSchemaCore
-	if o.Schema != "" && o.Schema != Draft202012 {
-		errs = append(errs, newValidationError(joinLoc(location, "schema"), "must be '%s', but got '%s'", Draft202012, o.Schema))
+	// JsonSchemaCore: only verify $schema is an absolute URI when present (no longer force Draft202012)
+	if o.Schema != "" {
+		if u, err := url.Parse(o.Schema); err != nil || u == nil || u.Scheme == "" {
+			errs = append(errs, newValidationError(joinLoc(location, "schema"), "must be an absolute URI, got '%s'", o.Schema))
+		}
 	}
 	if len(o.Defs) > 0 {
 		for k, v := range o.Defs {
@@ -574,6 +577,9 @@ func (o *Schema) validateSpec(location string, validator *Validator) []*validati
 				errs = append(errs, newValidationError(joinLoc(location, "default"), e))
 			}
 		}
+		if o.Const != nil && !reflect.DeepEqual(o.Default, o.Const) {
+			errs = append(errs, newValidationError(joinLoc(location, "default"), "invalid value, expected to be equal to const value: %v", o.Const))
+		}
 		if len(o.Enum) > 0 {
 			var found bool
 			for _, v := range o.Enum {
@@ -588,6 +594,22 @@ func (o *Schema) validateSpec(location string, validator *Validator) []*validati
 		}
 	}
 
+	if len(o.Enum) > 0 {
+		// use O(n^2) reflect.DeepEqual comparison to safely handle non-comparable types (slices, maps, etc.)
+		for i, oi := range o.Enum {
+			for j, oj := range o.Enum[i+1:] {
+				if reflect.DeepEqual(oi, oj) {
+					errs = append(errs, newValidationError(joinLoc(location, "enum", j), "duplicate value found in enum: %v", oj))
+					break
+				}
+			}
+		}
+	}
+
+	if o.Const != nil && len(o.Enum) > 0 {
+		errs = append(errs, newValidationError(joinLoc(location, "const"), "cannot be used together with enum"))
+	}
+
 	if len(o.Examples) > 0 && !validator.opts.doNotValidateExamples {
 		for k, v := range o.Examples {
 			if e := validator.ValidateData(location, v); e != nil {
@@ -596,7 +618,47 @@ func (o *Schema) validateSpec(location string, validator *Validator) []*validati
 		}
 	}
 
+	// Traverse nested subschemas for object/array related keywords even when type is unspecified (spec allows omitting "type").
+	// Do NOT enforce type-specific numeric/string constraints unless the type explicitly includes them.
 	if o.Type == nil {
+		// object-like keywords
+		if o.Properties != nil {
+			for k, v := range o.Properties {
+				errs = append(errs, v.validateSpec(joinLoc(location, "properties", k), validator)...)
+			}
+		}
+		if o.PatternProperties != nil {
+			for k, v := range o.PatternProperties {
+				errs = append(errs, v.validateSpec(joinLoc(location, "patternProperties", k), validator)...)
+				if _, err := regexp.Compile(k); err != nil {
+					errs = append(errs, newValidationError(joinLoc(location, "patternProperties", k), err))
+				}
+			}
+		}
+		if o.AdditionalProperties != nil {
+			errs = append(errs, o.AdditionalProperties.validateSpec(joinLoc(location, "additionalProperties"), validator)...)
+		}
+		if o.UnevaluatedProperties != nil {
+			errs = append(errs, o.UnevaluatedProperties.validateSpec(joinLoc(location, "unevaluatedProperties"), validator)...)
+		}
+		if o.PropertyNames != nil {
+			errs = append(errs, o.PropertyNames.validateSpec(joinLoc(location, "propertyNames"), validator)...)
+		}
+		// array-like keywords
+		if o.Items != nil {
+			errs = append(errs, o.Items.validateSpec(joinLoc(location, "items"), validator)...)
+		}
+		if o.UnevaluatedItems != nil {
+			errs = append(errs, o.UnevaluatedItems.validateSpec(joinLoc(location, "unevaluatedItems"), validator)...)
+		}
+		if o.Contains != nil {
+			errs = append(errs, o.Contains.validateSpec(joinLoc(location, "contains"), validator)...)
+		}
+		if len(o.PrefixItems) > 0 {
+			for i, v := range o.PrefixItems {
+				errs = append(errs, v.validateSpec(joinLoc(location, "prefixItems", i), validator)...)
+			}
+		}
 		return errs
 	}
 	for _, t := range *o.Type {
@@ -629,6 +691,9 @@ func (o *Schema) validateSpec(location string, validator *Validator) []*validati
 					errs = append(errs, newValidationError(joinLoc(location, "maxContains"), "must be greater than or equal to minContains"))
 				}
 			}
+			if (o.MinContains != nil || o.MaxContains != nil) && o.Contains == nil {
+				errs = append(errs, newValidationError(joinLoc(location, "contains"), "'contains' keyword is required when using minContains or maxContains"))
+			}
 			if len(o.PrefixItems) > 0 {
 				for i, v := range o.PrefixItems {
 					errs = append(errs, v.validateSpec(joinLoc(location, "prefixItems", i), validator)...)
@@ -651,8 +716,8 @@ func (o *Schema) validateSpec(location string, validator *Validator) []*validati
 			if o.AdditionalProperties != nil {
 				errs = append(errs, o.AdditionalProperties.validateSpec(joinLoc(location, "additionalProperties"), validator)...)
 			}
-			if o.UnevaluatedItems != nil {
-				errs = append(errs, o.UnevaluatedItems.validateSpec(joinLoc(location, "unevaluatedItems"), validator)...)
+			if o.UnevaluatedProperties != nil {
+				errs = append(errs, o.UnevaluatedProperties.validateSpec(joinLoc(location, "UnevaluatedProperties"), validator)...)
 			}
 			if o.PropertyNames != nil {
 				errs = append(errs, o.PropertyNames.validateSpec(joinLoc(location, "propertyNames"), validator)...)
@@ -677,23 +742,11 @@ func (o *Schema) validateSpec(location string, validator *Validator) []*validati
 			if o.MultipleOf != nil && *o.MultipleOf <= 0 {
 				errs = append(errs, newValidationError(joinLoc(location, "multipleOf"), "must be greater than 0"))
 			}
-			if o.Minimum != nil && *o.Minimum < 0 {
-				errs = append(errs, newValidationError(joinLoc(location, "minimum"), "must be greater than or equal to 0"))
+			if o.Minimum != nil && o.Maximum != nil && *o.Maximum < *o.Minimum {
+				errs = append(errs, newValidationError(joinLoc(location, "maximum"), "must be greater than or equal to minimum"))
 			}
-			if o.Maximum != nil && *o.Maximum < 0 {
-				errs = append(errs, newValidationError(joinLoc(location, "maximum"), "must be greater than or equal to 0"))
-				if o.Minimum != nil && *o.Maximum < *o.Minimum {
-					errs = append(errs, newValidationError(joinLoc(location, "maximum"), "must be greater than or equal to minimum"))
-				}
-			}
-			if o.ExclusiveMinimum != nil && *o.ExclusiveMinimum < 0 {
-				errs = append(errs, newValidationError(joinLoc(location, "exclusiveMinimum"), "must be greater than or equal to 0"))
-			}
-			if o.ExclusiveMaximum != nil && *o.ExclusiveMaximum < 0 {
-				errs = append(errs, newValidationError(joinLoc(location, "exclusiveMaximum"), "must be greater than or equal to 0"))
-				if o.ExclusiveMinimum != nil && *o.ExclusiveMaximum < *o.ExclusiveMinimum {
-					errs = append(errs, newValidationError(joinLoc(location, "exclusiveMaximum"), "must be greater than or equal to exclusiveMinimum"))
-				}
+			if o.ExclusiveMinimum != nil && o.ExclusiveMaximum != nil && *o.ExclusiveMaximum < *o.ExclusiveMinimum {
+				errs = append(errs, newValidationError(joinLoc(location, "exclusiveMaximum"), "must be greater than or equal to exclusiveMinimum"))
 			}
 			if o.Minimum != nil && o.ExclusiveMinimum != nil {
 				errs = append(errs, newValidationError(joinLoc(location, "minimum&exclusiveMinimum"), ErrMutuallyExclusive))
@@ -886,7 +939,7 @@ func (b *SchemaBuilder) Description(v string) *SchemaBuilder {
 	return b
 }
 
-func (b *SchemaBuilder) Const(v string) *SchemaBuilder {
+func (b *SchemaBuilder) Const(v any) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1100,7 +1153,7 @@ func (b *SchemaBuilder) Else(v *RefOrSpec[Schema]) *SchemaBuilder {
 	return b
 }
 
-func (b *SchemaBuilder) MultipleOf(v int) *SchemaBuilder {
+func (b *SchemaBuilder) MultipleOf(v float64) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1108,7 +1161,7 @@ func (b *SchemaBuilder) MultipleOf(v int) *SchemaBuilder {
 	return b
 }
 
-func (b *SchemaBuilder) Minimum(v int) *SchemaBuilder {
+func (b *SchemaBuilder) Minimum(v float64) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1116,7 +1169,7 @@ func (b *SchemaBuilder) Minimum(v int) *SchemaBuilder {
 	return b
 }
 
-func (b *SchemaBuilder) ExclusiveMinimum(v int) *SchemaBuilder {
+func (b *SchemaBuilder) ExclusiveMinimum(v float64) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1124,7 +1177,7 @@ func (b *SchemaBuilder) ExclusiveMinimum(v int) *SchemaBuilder {
 	return b
 }
 
-func (b *SchemaBuilder) Maximum(v int) *SchemaBuilder {
+func (b *SchemaBuilder) Maximum(v float64) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}
@@ -1132,7 +1185,7 @@ func (b *SchemaBuilder) Maximum(v int) *SchemaBuilder {
 	return b
 }
 
-func (b *SchemaBuilder) ExclusiveMaximum(v int) *SchemaBuilder {
+func (b *SchemaBuilder) ExclusiveMaximum(v float64) *SchemaBuilder {
 	if b.spec.Ref != nil {
 		return b
 	}

--- a/schema.go
+++ b/schema.go
@@ -746,7 +746,7 @@ func (o *Schema) validateSpec(location string, validator *Validator) []*validati
 				errs = append(errs, newValidationError(joinLoc(location, "maximum"), "must be greater than or equal to minimum"))
 			}
 			if o.ExclusiveMinimum != nil && o.ExclusiveMaximum != nil && *o.ExclusiveMaximum < *o.ExclusiveMinimum {
-				errs = append(errs, newValidationError(joinLoc(location, "exclusiveMaximum"), "must be greater than or equal to exclusiveMinimum"))
+				errs = append(errs, newValidationError(joinLoc(location, "exclusiveMaximum"), "must be greater than exclusiveMinimum"))
 			}
 			if o.Minimum != nil && o.ExclusiveMinimum != nil {
 				errs = append(errs, newValidationError(joinLoc(location, "minimum&exclusiveMinimum"), ErrMutuallyExclusive))

--- a/schema_test.go
+++ b/schema_test.go
@@ -94,3 +94,187 @@ func TestSchema_AddExt(t *testing.T) {
 		})
 	}
 }
+
+func TestSchemaConstWithMatchingDefaultInteger(t *testing.T) {
+	spec := openapi.NewOpenAPIBuilder().
+		Info(openapi.NewInfoBuilder().Title("Spec").Version("1.0.0").Build()).
+		Components(openapi.NewComponents()).
+		AddComponent("Number", openapi.NewSchemaBuilder().
+			AddType("integer").
+			Const(5).
+			Default(5).
+			Build()).
+		Build()
+	v, err := openapi.NewValidator(spec, openapi.AllowUnusedComponents())
+	require.NoError(t, err)
+	require.NoError(t, v.ValidateSpec())
+}
+
+func TestSchemaConstWithNonMatchingDefaultError(t *testing.T) {
+	spec := openapi.NewOpenAPIBuilder().
+		Info(openapi.NewInfoBuilder().Title("Spec").Version("1.0.0").Build()).
+		Components(openapi.NewComponents()).
+		AddComponent("Number", openapi.NewSchemaBuilder().
+			AddType("integer").
+			Const(5).
+			Default(6).
+			Build()).
+		Build()
+	v, err := openapi.NewValidator(spec, openapi.AllowUnusedComponents())
+	require.NoError(t, err)
+	err = v.ValidateSpec()
+	require.ErrorContains(t, err, "expected to be equal to const value")
+}
+
+func TestSchemaEnumDuplicateValueError(t *testing.T) {
+	spec := openapi.NewOpenAPIBuilder().
+		Info(openapi.NewInfoBuilder().Title("Spec").Version("1.0.0").Build()).
+		Components(openapi.NewComponents()).
+		AddComponent("DuplicateEnum", openapi.NewSchemaBuilder().
+			AddType("integer").
+			Enum(1, 1).
+			Build()).
+		Build()
+	v, err := openapi.NewValidator(spec, openapi.AllowUnusedComponents())
+	require.NoError(t, err)
+	err = v.ValidateSpec()
+	require.ErrorContains(t, err, "duplicate value found in enum")
+}
+
+func TestSchemaConstWithEnumConflict(t *testing.T) {
+	spec := openapi.NewOpenAPIBuilder().
+		Info(openapi.NewInfoBuilder().Title("Spec").Version("1.0.0").Build()).
+		Components(openapi.NewComponents()).
+		AddComponent("ConstEnum", openapi.NewSchemaBuilder().
+			AddType("integer").
+			Const(1).
+			Enum(1).
+			Build()).
+		Build()
+	v, err := openapi.NewValidator(spec, openapi.AllowUnusedComponents())
+	require.NoError(t, err)
+	err = v.ValidateSpec()
+	require.ErrorContains(t, err, "cannot be used together with enum")
+}
+
+func TestSchemaFractionalMultipleOfAllowed(t *testing.T) {
+	spec := openapi.NewOpenAPIBuilder().
+		Info(openapi.NewInfoBuilder().Title("Spec").Version("1.0.0").Build()).
+		Components(openapi.NewComponents()).
+		AddComponent("Price", openapi.NewSchemaBuilder().
+			AddType("number").
+			MultipleOf(0.01).
+			Minimum(0.0).
+			Maximum(100.0).
+			Build()).
+		Build()
+	v, err := openapi.NewValidator(spec, openapi.AllowUnusedComponents())
+	require.NoError(t, err)
+	require.NoError(t, v.ValidateSpec())
+}
+
+func TestSchemaInvalidMaximumLessThanMinimumError(t *testing.T) {
+	spec := openapi.NewOpenAPIBuilder().
+		Info(openapi.NewInfoBuilder().Title("Spec").Version("1.0.0").Build()).
+		Components(openapi.NewComponents()).
+		AddComponent("Range", openapi.NewSchemaBuilder().
+			AddType("number").
+			Minimum(10.0).
+			Maximum(5.0).
+			Build()).
+		Build()
+	v, err := openapi.NewValidator(spec, openapi.AllowUnusedComponents())
+	require.NoError(t, err)
+	err = v.ValidateSpec()
+	require.ErrorContains(t, err, "must be greater than or equal to minimum")
+}
+
+func TestSchemaExclusiveMaximumLessThanExclusiveMinimumError(t *testing.T) {
+	spec := openapi.NewOpenAPIBuilder().
+		Info(openapi.NewInfoBuilder().Title("Spec").Version("1.0.0").Build()).
+		Components(openapi.NewComponents()).
+		AddComponent("ExclusiveRange", openapi.NewSchemaBuilder().
+			AddType("number").
+			ExclusiveMinimum(10.0).
+			ExclusiveMaximum(5.0).
+			Build()).
+		Build()
+	v, err := openapi.NewValidator(spec, openapi.AllowUnusedComponents())
+	require.NoError(t, err)
+	err = v.ValidateSpec()
+	require.ErrorContains(t, err, "exclusiveMaximum")
+}
+
+func TestSchemaDollarSchemaAbsoluteURIOk(t *testing.T) {
+	spec := openapi.NewOpenAPIBuilder().
+		Info(openapi.NewInfoBuilder().Title("Spec").Version("1.0.0").Build()).
+		Components(openapi.NewComponents()).
+		AddComponent("DialectSchema", openapi.NewSchemaBuilder().
+			Schema("https://example.com/my-dialect").
+			AddType("string").
+			Build()).
+		Build()
+	v, err := openapi.NewValidator(spec, openapi.AllowUnusedComponents())
+	require.NoError(t, err)
+	require.NoError(t, v.ValidateSpec())
+}
+
+func TestSchemaDollarSchemaNonAbsoluteURIError(t *testing.T) {
+	spec := openapi.NewOpenAPIBuilder().
+		Info(openapi.NewInfoBuilder().Title("Spec").Version("1.0.0").Build()).
+		Components(openapi.NewComponents()).
+		AddComponent("BadDialect", openapi.NewSchemaBuilder().
+			Schema("not-absolute").
+			AddType("string").
+			Build()).
+		Build()
+	v, err := openapi.NewValidator(spec, openapi.AllowUnusedComponents())
+	require.NoError(t, err)
+	err = v.ValidateSpec()
+	require.ErrorContains(t, err, "must be an absolute URI")
+}
+
+func TestSchema_MaxContainsWithoutContains_Error(t *testing.T) {
+	spec := openapi.NewOpenAPIBuilder().
+		Info(openapi.NewInfoBuilder().Title("Spec").Version("1.0.0").Build()).
+		Components(openapi.NewComponents()).
+		AddComponent("ArrayNoContainsMax", openapi.NewSchemaBuilder().
+			AddType("array").
+			MaxContains(2).
+			Build()).
+		Build()
+	v, err := openapi.NewValidator(spec, openapi.AllowUnusedComponents())
+	require.NoError(t, err)
+	err = v.ValidateSpec()
+	require.ErrorContains(t, err, "'contains' keyword is required")
+}
+
+func TestOperationID_Unique_OK(t *testing.T) {
+	path1 := openapi.NewPathItemBuilder().Get(openapi.NewOperationBuilder().OperationID("opA").Build()).Build()
+	path2 := openapi.NewPathItemBuilder().Get(openapi.NewOperationBuilder().OperationID("opB").Build()).Build()
+	spec := openapi.NewOpenAPIBuilder().
+		Info(openapi.NewInfoBuilder().Title("Spec").Version("1.0.0").Build()).
+		Paths(openapi.NewPaths()).
+		Build()
+	spec.Spec.Paths.Spec.Add("/a", path1)
+	spec.Spec.Paths.Spec.Add("/b", path2)
+	v, err := openapi.NewValidator(spec)
+	require.NoError(t, err)
+	require.NoError(t, v.ValidateSpec())
+}
+
+func TestSchema_EnumUniqueness_SliceDuplicate(t *testing.T) {
+	dup := []any{"a", 1}
+	spec := openapi.NewOpenAPIBuilder().
+		Info(openapi.NewInfoBuilder().Title("Spec").Version("1.0.0").Build()).
+		Components(openapi.NewComponents()).
+		AddComponent("SliceEnum", openapi.NewSchemaBuilder().
+			AddType("array"). // type itself not critical
+			Enum(dup, dup).
+			Build()).
+		Build()
+	v, err := openapi.NewValidator(spec, openapi.AllowUnusedComponents())
+	require.NoError(t, err)
+	err = v.ValidateSpec()
+	require.ErrorContains(t, err, "duplicate value found in enum")
+}


### PR DESCRIPTION
Add a suite of new unit tests for OpenAPI schema validation covering
const/default interactions, enum uniqueness and conflicts, numeric
constraints, exclusive bounds, fraction multipleOf behavior, and schema
"dollarSchema" URI validation.

Key additions:
- TestSchemaConstWithMatchingDefaultInteger and
  TestSchemaConstWithNonMatchingDefaultError to validate const vs default
  value handling.
- TestSchemaEnumDuplicateValueError and TestSchemaConstWithEnumConflict to
  ensure enums reject duplicate values and incompatible const+enum usage.
- TestSchemaFractionalMultipleOfAllowed to allow fractional multipleOf
  (e.g., 0.01) with numeric ranges.
- TestSchemaInvalidMaximumLessThanMinimumError and
  TestSchemaExclusiveMaximumLessThanExclusiveMinimumError to enforce min/max
  ordering for inclusive and exclusive bounds.
- TestSchemaDollarSchemaAbsoluteURIOk and
  TestSchemaDollarSchemaNonAbsoluteURIError to require dollarSchema be an
  absolute URI.
- Begin adding TestSchema_MaxContainsWithoutContains_Error (incomplete in
  diff) to cover contains/maxContains relationships.

These tests increase coverage of schema validation rules and prevent
regressions by asserting both valid schemas pass and invalid schemas
produce descriptive errors.