### PR TITLE
fix: change Explode field from bool to *bool for proper serialization

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -64,7 +64,7 @@ type Encoding struct {
 	// For all other styles, the default value is false.
 	// This property SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data.
 	// If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored.
-	Explode bool `json:"explode,omitempty" yaml:"explode,omitempty"`
+	Explode *bool `json:"explode,omitempty" yaml:"explode,omitempty"`
 	// Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986]
 	//   :/?#[]@!$&'()*+,;=
 	// to be included without percent-encoding.
@@ -138,7 +138,7 @@ func (b *EncodingBuilder) Style(v string) *EncodingBuilder {
 }
 
 func (b *EncodingBuilder) Explode(v bool) *EncodingBuilder {
-	b.spec.Spec.Explode = v
+	b.spec.Spec.Explode = &v
 	return b
 }
 

--- a/header.go
+++ b/header.go
@@ -29,7 +29,7 @@ type Header struct {
 	// For other types of parameters this property has no effect.
 	// When style is form, the default value is true.
 	// For all other styles, the default value is false.
-	Explode bool `json:"explode,omitempty" yaml:"explode,omitempty"`
+	Explode *bool `json:"explode,omitempty" yaml:"explode,omitempty"`
 	// Determines whether this header is mandatory.
 	// The property MAY be included and its default value is false.
 	Required bool `json:"required,omitempty" yaml:"required,omitempty"`
@@ -118,7 +118,7 @@ func (b *HeaderBuilder) Style(v string) *HeaderBuilder {
 }
 
 func (b *HeaderBuilder) Explode(v bool) *HeaderBuilder {
-	b.spec.Spec.Spec.Explode = v
+	b.spec.Spec.Spec.Explode = &v
 	return b
 }
 

--- a/parameter.go
+++ b/parameter.go
@@ -155,7 +155,7 @@ type Parameter struct {
 	// For other types of parameters this property has no effect.
 	// When style is form, the default value is true.
 	// For all other styles, the default value is false.
-	Explode bool `json:"explode,omitempty" yaml:"explode,omitempty"`
+	Explode *bool `json:"explode,omitempty" yaml:"explode,omitempty"`
 	// Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986]
 	//   :/?#[]@!$&'()*+,;=
 	// to be included without percent-encoding.
@@ -370,7 +370,7 @@ func (b *ParameterBuilder) Name(v string) *ParameterBuilder {
 }
 
 func (b *ParameterBuilder) Explode(v bool) *ParameterBuilder {
-	b.spec.Spec.Spec.Explode = v
+	b.spec.Spec.Spec.Explode = &v
 	return b
 }
 


### PR DESCRIPTION
## Problem

When `Explode` is `bool` with `omitempty` JSON/YAML tag, `false` values are not serialized to the output. This prevents users from explicitly setting `explode: false` in OpenAPI specs.

For example:
```go
type Parameter struct {
    Explode bool `json:"explode,omitempty" yaml:"explode,omitempty"`
}

p := Parameter{Explode: false}
yaml.Marshal(p) // Output: {} - Explode field is missing!
```

## Solution

Change `Explode` from `bool` to `*bool` in:
- `Parameter` struct (parameter.go)
- `Header` struct (header.go)
- `Encoding` struct (encoding.go)

This allows:
- `nil` → omit the field (use default behavior)
- `&true` → serialize as `explode: true`
- `&false` → serialize as `explode: false`

The builder methods are updated to take address of the value.

## Changes

- `parameter.go`: `Explode bool` → `Explode *bool`, builder updated
- `header.go`: `Explode bool` → `Explode *bool`, builder updated
- `encoding.go`: `Explode bool` → `Explode *bool`, builder updated

## Testing

All existing tests pass.

## Related

This change is needed to support explicit `explode: false` generation in tools like [swaggo/swag](https://github.com/swaggo/swag/issues/2134).